### PR TITLE
fix some k8s bug and improve some code

### DIFF
--- a/computer-algorithm/Dockerfile
+++ b/computer-algorithm/Dockerfile
@@ -1,9 +1,6 @@
 FROM hugegraph/hugegraph-computer-framework:latest
-
 LABEL maintainer="HugeGraph Docker Maintainers <hugegraph@googlegroups.com>"
 
 ARG jarFilePath="/opt/jars/computer-algorithm-based.jar"
-
 COPY target/computer-algorithm-*.jar ${jarFilePath}
-
 ENV JAR_FILE_PATH=${jarFilePath}

--- a/computer-k8s-operator/Dockerfile
+++ b/computer-k8s-operator/Dockerfile
@@ -3,5 +3,5 @@ LABEL maintainer="HugeGraph Docker Maintainers <hugegraph@googlegroups.com>"
 
 ENV JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=2 -XshowSettings:vm"
 WORKDIR /opt/app
-COPY target/hugegraph-computer-operator.jar operator.jar
-ENTRYPOINT ["java", "-jar", "operator.jar"]
+COPY target/hugegraph-computer-operator-*.jar hugegraph-computer-operator.jar
+ENTRYPOINT ["java", "-jar", "hugegraph-computer-operator.jar"]

--- a/computer-k8s-operator/crd-generate/config/manager/manager.yaml
+++ b/computer-k8s-operator/crd-generate/config/manager/manager.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: manager
-        command: ["java", "-jar", "operator.jar"]
+        command: ["java", "-jar", "hugegraph-computer-operator.jar"]
         args: []
         image: controller:latest
         imagePullPolicy: Always
@@ -31,6 +31,8 @@ spec:
             value: "http://hugegraph-computer-operator-etcd.hugegraph-computer-operator-system:2379"
           - name: LOG_LEVEL
             value: "INFO"
+          - name: AUTO_DESTROY_POD
+            value: "true"
         livenessProbe:
           httpGet:
             path: /health

--- a/computer-k8s-operator/manifest/hugegraph-computer-operator.yaml
+++ b/computer-k8s-operator/manifest/hugegraph-computer-operator.yaml
@@ -376,7 +376,7 @@ spec:
         command:
         - java
         - -jar
-        - operator.jar
+        - hugegraph-computer-operator.jar
         env:
         - name: PROBE_PORT
           value: "9892"
@@ -388,6 +388,8 @@ spec:
           value: http://hugegraph-computer-operator-etcd.hugegraph-computer-operator-system:2379
         - name: LOG_LEVEL
           value: INFO
+        - name: AUTO_DESTROY_POD
+          value: "true"
         image: hugegraph/hugegraph-computer-operator:latest
         imagePullPolicy: Always
         livenessProbe:

--- a/computer-k8s-operator/pom.xml
+++ b/computer-k8s-operator/pom.xml
@@ -20,7 +20,7 @@
     </dependencies>
 
     <build>
-        <finalName>hugegraph-computer-operator</finalName>
+        <finalName>hugegraph-computer-operator-${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/computer-k8s-operator/src/main/java/com/baidu/hugegraph/computer/k8s/operator/OperatorEntrypoint.java
+++ b/computer-k8s-operator/src/main/java/com/baidu/hugegraph/computer/k8s/operator/OperatorEntrypoint.java
@@ -168,6 +168,11 @@ public class OperatorEntrypoint {
             this.controllerPool = null;
         }
 
+        if (this.informerFactory != null) {
+            this.informerFactory.stopAllRegisteredInformers();
+            this.informerFactory = null;
+        }
+
         if (this.kubeClient != null) {
             this.kubeClient.close();
             this.kubeClient = null;

--- a/computer-k8s-operator/src/main/java/com/baidu/hugegraph/computer/k8s/operator/config/OperatorOptions.java
+++ b/computer-k8s-operator/src/main/java/com/baidu/hugegraph/computer/k8s/operator/config/OperatorOptions.java
@@ -19,6 +19,7 @@
 
 package com.baidu.hugegraph.computer.k8s.operator.config;
 
+import static com.baidu.hugegraph.config.OptionChecker.allowValues;
 import static com.baidu.hugegraph.config.OptionChecker.disallowEmpty;
 import static com.baidu.hugegraph.config.OptionChecker.positiveInt;
 
@@ -133,5 +134,14 @@ public class OperatorOptions extends OptionHolder {
                     "The internal etcd url for operator system.",
                     disallowEmpty(),
                     "http://127.0.0.1:2379"
+            );
+
+    public static final ConfigOption<Boolean> AUTO_DESTROY_POD =
+            new ConfigOption<>(
+                    "k8s.auto_destroy_pod",
+                    "Whether to automatically destroy all pods when the job " +
+                    "is completed or failed.",
+                    allowValues(true, false),
+                    true
             );
 }

--- a/computer-k8s-operator/src/main/java/com/baidu/hugegraph/computer/k8s/operator/controller/ComputerJobController.java
+++ b/computer-k8s-operator/src/main/java/com/baidu/hugegraph/computer/k8s/operator/controller/ComputerJobController.java
@@ -99,8 +99,8 @@ public class ComputerJobController
     protected OperatorResult reconcile(OperatorRequest request) {
         HugeGraphComputerJob computerJob = this.getCR(request);
         if (computerJob == null) {
-            LOG.debug("Unable to fetch HugeGraphComputerJob, " +
-                      "it may have been deleted");
+            LOG.debug("Unable to fetch HugeGraphComputerJob {}, " +
+                      "it may have been deleted", request.name());
             return OperatorResult.NO_REQUEUE;
         }
 

--- a/computer-k8s-operator/src/main/java/com/baidu/hugegraph/computer/k8s/operator/controller/ComputerJobController.java
+++ b/computer-k8s-operator/src/main/java/com/baidu/hugegraph/computer/k8s/operator/controller/ComputerJobController.java
@@ -316,8 +316,9 @@ public class ComputerJobController
                 newState.setMessage(failedPullImage.msg());
                 failedComponents.increment();
             } else {
-                int active = KubeUtil.intVal(job.getStatus().getActive());
-                active = active + succeeded;
+                int running = pods.stream().filter(PodStatusUtil::isRunning)
+                                  .mapToInt(x -> 1).sum();
+                int active = running + succeeded;
                 if (active >= instances) {
                     newState.setState(JobComponentState.RUNNING.value());
                     runningComponents.increment();

--- a/computer-k8s-operator/src/main/java/com/baidu/hugegraph/computer/k8s/operator/controller/ComputerJobController.java
+++ b/computer-k8s-operator/src/main/java/com/baidu/hugegraph/computer/k8s/operator/controller/ComputerJobController.java
@@ -257,7 +257,7 @@ public class ComputerJobController
             this.recordEvent(computerJob, EventType.NORMAL,
                              KubeUtil.succeedEventName(crName),
                              "ComputerJobSucceed",
-                             String.format("Job %s run success, run cost %ss",
+                             String.format("Job %s run successfully, took %ss",
                                            crName, cost));
             return status;
         }

--- a/computer-k8s-operator/src/main/java/com/baidu/hugegraph/computer/k8s/operator/controller/ComputerJobController.java
+++ b/computer-k8s-operator/src/main/java/com/baidu/hugegraph/computer/k8s/operator/controller/ComputerJobController.java
@@ -47,6 +47,7 @@ import com.baidu.hugegraph.computer.k8s.operator.common.AbstractController;
 import com.baidu.hugegraph.computer.k8s.operator.common.MatchWithMsg;
 import com.baidu.hugegraph.computer.k8s.operator.common.OperatorRequest;
 import com.baidu.hugegraph.computer.k8s.operator.common.OperatorResult;
+import com.baidu.hugegraph.computer.k8s.operator.config.OperatorOptions;
 import com.baidu.hugegraph.computer.k8s.util.KubeUtil;
 import com.baidu.hugegraph.config.HugeConfig;
 import com.baidu.hugegraph.util.Log;
@@ -77,6 +78,7 @@ public class ComputerJobController
 
     private final MixedOperation<HugeGraphComputerJob, HugeGraphComputerJobList,
             Resource<HugeGraphComputerJob>> operation;
+    private final Boolean autoDestroyPod;
 
     private static final int TOTAL_COMPONENTS = 2;
     private static final int ALLOW_FAILED_JOBS = 0;
@@ -94,6 +96,7 @@ public class ComputerJobController
         this.operation = this.kubeClient.customResources(
                                          HugeGraphComputerJob.class,
                                          HugeGraphComputerJobList.class);
+        this.autoDestroyPod = this.config.get(OperatorOptions.AUTO_DESTROY_POD);
     }
 
     @Override
@@ -171,7 +174,9 @@ public class ComputerJobController
             return true;
         } else {
             if (JobStatus.finished(status.getJobStatus())) {
-                this.deleteCR(computerJob);
+                if (this.autoDestroyPod) {
+                    this.deleteCR(computerJob);
+                }
                 return true;
             }
         }

--- a/computer-k8s-operator/src/main/resources/log4j2.xml
+++ b/computer-k8s-operator/src/main/resources/log4j2.xml
@@ -14,7 +14,7 @@
 
         <RollingFile name="file" fileName="${LOG_PATH}/${FILE_NAME}.log"
                      filePattern="${LOG_PATH}/$${date:yyyy-MM}/${FILE_NAME}-%d{yyyy-MM-dd}-%i.log">
-            <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            <ThresholdFilter level="${env:LOG_LEVEL:-INFO}" onMatch="ACCEPT" onMismatch="DENY"/>
             <PatternLayout pattern="%-d{yyyy-MM-dd HH:mm:ss} %-5r [%t] [%-5p] %c %x - %m%n"/>
             <SizeBasedTriggeringPolicy size="100MB"/>
         </RollingFile>

--- a/computer-k8s/pom.xml
+++ b/computer-k8s/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>computer-k8s</artifactId>
 
     <properties>
-        <fabric8.version>5.5.0</fabric8.version>
+        <fabric8.version>5.6.0</fabric8.version>
         <lombok.version>1.18.0</lombok.version>
         <sundrio.version>0.40.1</sundrio.version>
         <maven.jsonschema2pojo.plugin.version>1.1.0</maven.jsonschema2pojo.plugin.version>

--- a/computer-k8s/src/main/java/com/baidu/hugegraph/computer/k8s/util/KubeUtil.java
+++ b/computer-k8s/src/main/java/com/baidu/hugegraph/computer/k8s/util/KubeUtil.java
@@ -142,8 +142,8 @@ public class KubeUtil {
         return OffsetDateTime.now().toString();
     }
 
-    public static int intVal(Integer integer) {
-        return integer != null ? integer : 0;
+    public static int intVal(Integer value) {
+        return value != null ? value : 0;
     }
 
     public static String asProperties(Map<String, String> map) {

--- a/computer-k8s/src/main/java/com/baidu/hugegraph/computer/k8s/util/KubeUtil.java
+++ b/computer-k8s/src/main/java/com/baidu/hugegraph/computer/k8s/util/KubeUtil.java
@@ -143,7 +143,7 @@ public class KubeUtil {
     }
 
     public static int intVal(Integer integer) {
-        return integer != null ? integer : -1;
+        return integer != null ? integer : 0;
     }
 
     public static String asProperties(Map<String, String> map) {

--- a/computer-test/pom.xml
+++ b/computer-test/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-server-mock</artifactId>
-            <version>5.5.0</version>
+            <version>5.6.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/AbstractK8sTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/AbstractK8sTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.configuration.MapConfiguration;
 import org.junit.After;
@@ -51,6 +52,7 @@ import com.google.common.collect.Lists;
 
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -198,10 +200,13 @@ public abstract class AbstractK8sTest {
     }
 
     private void createCRD(KubernetesClient client) {
-        client.apiextensions().v1beta1()
-              .customResourceDefinitions()
-              .load(new File("../computer-k8s-operator/manifest" +
-                             "/hugegraph-computer-crd.v1beta1.yaml"))
-              .createOrReplace();
+        Resource<CustomResourceDefinition> cr = client
+                .apiextensions()
+                .v1beta1()
+                .customResourceDefinitions()
+                .load(new File("../computer-k8s-operator/manifest" +
+                               "/hugegraph-computer-crd.v1beta1.yaml"));
+        cr.createOrReplace();
+        cr.waitUntilCondition(Objects::nonNull, 5, TimeUnit.SECONDS);
     }
 }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/AbstractK8sTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/AbstractK8sTest.java
@@ -46,6 +46,7 @@ import com.baidu.hugegraph.computer.k8s.util.KubeUtil;
 import com.baidu.hugegraph.computer.suite.unit.UnitTestBase;
 import com.baidu.hugegraph.config.HugeConfig;
 import com.baidu.hugegraph.config.OptionSpace;
+import com.baidu.hugegraph.testutil.Assert;
 import com.baidu.hugegraph.testutil.Whitebox;
 import com.baidu.hugegraph.util.ExecutorUtil;
 import com.google.common.collect.Lists;
@@ -200,13 +201,14 @@ public abstract class AbstractK8sTest {
     }
 
     private void createCRD(KubernetesClient client) {
-        Resource<CustomResourceDefinition> cr = client
+        Resource<CustomResourceDefinition> crd = client
                 .apiextensions()
                 .v1beta1()
                 .customResourceDefinitions()
                 .load(new File("../computer-k8s-operator/manifest" +
                                "/hugegraph-computer-crd.v1beta1.yaml"));
-        cr.createOrReplace();
-        cr.waitUntilCondition(Objects::nonNull, 5, TimeUnit.SECONDS);
+        crd.createOrReplace();
+        crd.waitUntilReady(10, TimeUnit.SECONDS);
+        Assert.assertNotNull(crd.get());
     }
 }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/AbstractK8sTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/AbstractK8sTest.java
@@ -174,6 +174,7 @@ public abstract class AbstractK8sTest {
     }
 
     protected void initOperator() {
+        this.operation.delete(this.operation.list().getItems());
         ExecutorService pool = ExecutorUtil.newFixedThreadPool("operator-test");
         this.operatorFuture = pool.submit(() -> {
             String watchNameSpace = Utils.getSystemPropertyOrEnvVar(

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/MiniKubeTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/MiniKubeTest.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
 import org.apache.http.HttpResponse;
@@ -35,6 +36,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -62,8 +64,7 @@ import io.fabric8.kubernetes.api.model.Quantity;
 public class MiniKubeTest extends AbstractK8sTest {
 
     private static final String ALGORITHM_NAME = "PageRank";
-    private static final ExecutorService POOL =
-            ExecutorUtil.newFixedThreadPool(1, "minikube-test-pool");
+    private static ExecutorService POOL;
 
     @Before
     public void setup() throws IOException {
@@ -74,7 +75,18 @@ public class MiniKubeTest extends AbstractK8sTest {
         this.namespace = "minikube";
         System.setProperty(OperatorOptions.WATCH_NAMESPACE.name(),
                            Constants.ALL_NAMESPACE);
+
+        POOL = ExecutorUtil.newFixedThreadPool(1, "minikube-test-pool");
+
         super.setup();
+    }
+
+    @After
+    public void teardown() throws InterruptedException,
+                                  ExecutionException,
+                                  IOException {
+        POOL.shutdown();
+        super.teardown();
     }
 
     @Test

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/MiniKubeTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/MiniKubeTest.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
 import org.apache.http.HttpResponse;
@@ -36,8 +35,9 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -66,6 +66,16 @@ public class MiniKubeTest extends AbstractK8sTest {
     private static final String ALGORITHM_NAME = "PageRank";
     private static ExecutorService POOL;
 
+    @BeforeClass
+    public static void setupClass() {
+        POOL = ExecutorUtil.newFixedThreadPool(1, "minikube-test-pool");
+    }
+
+    @AfterClass
+    public static void teardownClass() {
+        POOL.shutdown();
+    }
+
     @Before
     public void setup() throws IOException {
         String kubeconfigFilename = getKubeconfigFilename();
@@ -75,18 +85,7 @@ public class MiniKubeTest extends AbstractK8sTest {
         this.namespace = "minikube";
         System.setProperty(OperatorOptions.WATCH_NAMESPACE.name(),
                            Constants.ALL_NAMESPACE);
-
-        POOL = ExecutorUtil.newFixedThreadPool(1, "minikube-test-pool");
-
         super.setup();
-    }
-
-    @After
-    public void teardown() throws InterruptedException,
-                                  ExecutionException,
-                                  IOException {
-        POOL.shutdown();
-        super.teardown();
     }
 
     @Test

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/MiniKubeTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/MiniKubeTest.java
@@ -67,12 +67,12 @@ public class MiniKubeTest extends AbstractK8sTest {
     private static ExecutorService POOL;
 
     @BeforeClass
-    public static void setupClass() {
+    public static void init() {
         POOL = ExecutorUtil.newFixedThreadPool(1, "minikube-test-pool");
     }
 
     @AfterClass
-    public static void teardownClass() {
+    public static void clear() {
         POOL.shutdown();
     }
 

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/MiniKubeTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/MiniKubeTest.java
@@ -119,7 +119,7 @@ public class MiniKubeTest extends AbstractK8sTest {
 
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
             this.driver.waitJob(jobId, params, jobObserver);
-        });
+        }, POOL);
 
         DefaultJobState jobState = new DefaultJobState();
         jobState.jobStatus(JobStatus.INITIALIZING);

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/MiniKubeTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/MiniKubeTest.java
@@ -40,6 +40,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
 
 import com.baidu.hugegraph.computer.driver.DefaultJobState;
 import com.baidu.hugegraph.computer.driver.JobObserver;
@@ -56,12 +57,15 @@ import com.baidu.hugegraph.computer.suite.unit.UnitTestBase;
 import com.baidu.hugegraph.testutil.Assert;
 import com.baidu.hugegraph.testutil.Whitebox;
 import com.baidu.hugegraph.util.ExecutorUtil;
+import com.baidu.hugegraph.util.Log;
 import com.google.common.collect.Lists;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Quantity;
 
 public class MiniKubeTest extends AbstractK8sTest {
+
+    private static final Logger LOG = Log.logger(MiniKubeTest.class);
 
     private static final String ALGORITHM_NAME = "PageRank";
     private static ExecutorService POOL;
@@ -78,14 +82,19 @@ public class MiniKubeTest extends AbstractK8sTest {
 
     @Before
     public void setup() throws IOException {
-        String kubeconfigFilename = getKubeconfigFilename();
-        File file = new File(kubeconfigFilename);
-        Assert.assertTrue(file.exists());
+        try {
+            String kubeconfigFilename = getKubeconfigFilename();
+            File file = new File(kubeconfigFilename);
+            Assert.assertTrue(file.exists());
 
-        this.namespace = "minikube";
-        System.setProperty(OperatorOptions.WATCH_NAMESPACE.name(),
-                           Constants.ALL_NAMESPACE);
-        super.setup();
+            this.namespace = "minikube";
+            System.setProperty(OperatorOptions.WATCH_NAMESPACE.name(),
+                               Constants.ALL_NAMESPACE);
+            super.setup();
+        } catch (Throwable throwable) {
+            LOG.error("Failed to setup MiniKubeTest ", throwable);
+            throw throwable;
+        }
     }
 
     @Test

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/MiniKubeTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/k8s/MiniKubeTest.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -52,6 +53,7 @@ import com.baidu.hugegraph.computer.k8s.util.KubeUtil;
 import com.baidu.hugegraph.computer.suite.unit.UnitTestBase;
 import com.baidu.hugegraph.testutil.Assert;
 import com.baidu.hugegraph.testutil.Whitebox;
+import com.baidu.hugegraph.util.ExecutorUtil;
 import com.google.common.collect.Lists;
 
 import io.fabric8.kubernetes.api.model.Pod;
@@ -60,6 +62,8 @@ import io.fabric8.kubernetes.api.model.Quantity;
 public class MiniKubeTest extends AbstractK8sTest {
 
     private static final String ALGORITHM_NAME = "PageRank";
+    private static final ExecutorService POOL =
+            ExecutorUtil.newFixedThreadPool(1, "minikube-test-pool");
 
     @Before
     public void setup() throws IOException {
@@ -135,7 +139,7 @@ public class MiniKubeTest extends AbstractK8sTest {
 
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
             this.driver.waitJob(jobId, params, jobObserver);
-        });
+        }, POOL);
 
         DefaultJobState jobState = new DefaultJobState();
         jobState.jobStatus(JobStatus.INITIALIZING);
@@ -169,7 +173,7 @@ public class MiniKubeTest extends AbstractK8sTest {
 
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
             this.driver.waitJob(jobId, params, jobObserver);
-        });
+        }, POOL);
 
         DefaultJobState jobState = new DefaultJobState();
         jobState.jobStatus(JobStatus.INITIALIZING);
@@ -201,7 +205,7 @@ public class MiniKubeTest extends AbstractK8sTest {
 
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
             this.driver.waitJob(jobId, params, jobObserver);
-        });
+        }, POOL);
 
         DefaultJobState jobState = new DefaultJobState();
         jobState.jobStatus(JobStatus.FAILED);
@@ -233,7 +237,7 @@ public class MiniKubeTest extends AbstractK8sTest {
 
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
             this.driver.waitJob(jobId, params, jobObserver);
-        });
+        }, POOL);
 
         DefaultJobState jobState = new DefaultJobState();
         jobState.jobStatus(JobStatus.INITIALIZING);
@@ -269,7 +273,7 @@ public class MiniKubeTest extends AbstractK8sTest {
 
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
             this.driver.waitJob(jobId, params, jobObserver);
-        });
+        }, POOL);
 
         DefaultJobState jobState = new DefaultJobState();
         jobState.jobStatus(JobStatus.RUNNING);
@@ -302,7 +306,7 @@ public class MiniKubeTest extends AbstractK8sTest {
 
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
             this.driver.waitJob(jobId, params, jobObserver);
-        });
+        }, POOL);
 
         DefaultJobState jobState = new DefaultJobState();
         jobState.jobStatus(JobStatus.FAILED);
@@ -327,7 +331,7 @@ public class MiniKubeTest extends AbstractK8sTest {
 
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
             this.driver.waitJob(jobId, params, jobObserver);
-        });
+        }, POOL);
 
         DefaultJobState jobState = new DefaultJobState();
         jobState.jobStatus(JobStatus.INITIALIZING);


### PR DESCRIPTION
* fix the pod deleted when job failed
* fix job active state inaccurate
* upgrade fabric8 k8s client version to 5.6.0
* add job cost statistics
* add AUTO_DESTROY_POD option for operator
* improve k8s error log message
* use a separate thread for execution waitJob on unit test
* delete history job before run k8s test