### PR TITLE
improve: refactor combiner

### DIFF
--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/DoubleValueSumCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/DoubleValueSumCombiner.java
@@ -25,10 +25,11 @@ import com.baidu.hugegraph.util.E;
 public class DoubleValueSumCombiner implements Combiner<DoubleValue> {
 
     @Override
-    public DoubleValue combine(DoubleValue v1, DoubleValue v2) {
+    public void combine(DoubleValue v1, DoubleValue v2, DoubleValue result) {
         E.checkArgumentNotNull(v1, "The combine parameter v1 can't be null");
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
-        v2.value(v1.value() + v2.value());
-        return v2;
+        E.checkArgumentNotNull(result,
+                               "The combine parameter result can't be null");
+        result.value(v1.value() + v2.value());
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/DoubleValueSumCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/DoubleValueSumCombiner.java
@@ -30,6 +30,6 @@ public class DoubleValueSumCombiner implements Combiner<DoubleValue> {
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
         E.checkArgumentNotNull(result,
                                "The combine parameter result can't be null");
-        result.value(v1.value() + v2.value());
+        result.value(v1.doubleValue() + v2.doubleValue());
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/FloatValueSumCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/FloatValueSumCombiner.java
@@ -25,10 +25,11 @@ import com.baidu.hugegraph.util.E;
 public class FloatValueSumCombiner implements Combiner<FloatValue> {
 
     @Override
-    public FloatValue combine(FloatValue v1, FloatValue v2) {
+    public void combine(FloatValue v1, FloatValue v2, FloatValue result) {
         E.checkArgumentNotNull(v1, "The combine parameter v1 can't be null");
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
-        v2.value(v1.value() + v2.value());
-        return v2;
+        E.checkArgumentNotNull(result,
+                               "The combine parameter result can't be null");
+        result.value(v1.value() + v2.value());
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/FloatValueSumCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/FloatValueSumCombiner.java
@@ -30,6 +30,6 @@ public class FloatValueSumCombiner implements Combiner<FloatValue> {
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
         E.checkArgumentNotNull(result,
                                "The combine parameter result can't be null");
-        result.value(v1.value() + v2.value());
+        result.value(v1.floatValue() + v2.floatValue());
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/IntValueSumCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/IntValueSumCombiner.java
@@ -30,6 +30,6 @@ public class IntValueSumCombiner implements Combiner<IntValue> {
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
         E.checkArgumentNotNull(result,
                                "The combine parameter result can't be null");
-        result.value(v1.value() + v2.value());
+        result.value(v1.intValue() + v2.intValue());
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/IntValueSumCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/IntValueSumCombiner.java
@@ -25,10 +25,11 @@ import com.baidu.hugegraph.util.E;
 public class IntValueSumCombiner implements Combiner<IntValue> {
 
     @Override
-    public IntValue combine(IntValue v1, IntValue v2) {
+    public void combine(IntValue v1, IntValue v2, IntValue result) {
         E.checkArgumentNotNull(v1, "The combine parameter v1 can't be null");
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
-        v2.value(v1.value() + v2.value());
-        return v2;
+        E.checkArgumentNotNull(result,
+                               "The combine parameter result can't be null");
+        result.value(v1.value() + v2.value());
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/LongValueSumCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/LongValueSumCombiner.java
@@ -25,10 +25,11 @@ import com.baidu.hugegraph.util.E;
 public class LongValueSumCombiner implements Combiner<LongValue> {
 
     @Override
-    public LongValue combine(LongValue v1, LongValue v2) {
+    public void combine(LongValue v1, LongValue v2, LongValue result) {
         E.checkArgumentNotNull(v1, "The combine parameter v1 can't be null");
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
-        v2.value(v1.value() + v2.value());
-        return v2;
+        E.checkArgumentNotNull(result,
+                               "The combine parameter result can't be null");
+        result.value(v1.value() + v2.value());
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/LongValueSumCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/LongValueSumCombiner.java
@@ -30,6 +30,6 @@ public class LongValueSumCombiner implements Combiner<LongValue> {
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
         E.checkArgumentNotNull(result,
                                "The combine parameter result can't be null");
-        result.value(v1.value() + v2.value());
+        result.value(v1.longValue() + v2.longValue());
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeNewPropertiesCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeNewPropertiesCombiner.java
@@ -37,8 +37,9 @@ public class MergeNewPropertiesCombiner implements PropertiesCombiner {
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
         E.checkArgumentNotNull(result,
                                "The combine parameter result can't be null");
-        E.checkState(v1 != result && v2 != result,
-                     "The combine parameter result can't same with v1 or v2");
+        E.checkArgument(v1 != result && v2 != result,
+                        "The combine parameter result " +
+                        "can't same with v1 or v2");
 
         result.clear();
 

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeNewPropertiesCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeNewPropertiesCombiner.java
@@ -28,17 +28,23 @@ import com.baidu.hugegraph.util.E;
 public class MergeNewPropertiesCombiner implements PropertiesCombiner {
 
     /**
-     * Merge properties v2 into v1. If a property exists in both v1 and v2,
-     * remain the value in v1.
+     * Merge properties v2 and v1 into result. If a property exists in both v1
+     * and v2, remain the value in v1.
      */
     @Override
-    public Properties combine(Properties v1, Properties v2) {
+    public void combine(Properties v1, Properties v2, Properties result) {
         E.checkArgumentNotNull(v1, "The combine parameter v1 can't be null");
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
+        E.checkArgumentNotNull(result,
+                               "The combine parameter result can't be null");
         Map<String, Value> v2Map = v2.get();
         for (Map.Entry<String, Value> entry : v2Map.entrySet()) {
              v1.putIfAbsent(entry.getKey(), entry.getValue());
         }
-        return v1;
+        Map<String, Value> v1Map = v1.get();
+        Map<String, Value> resultMap = result.get();
+        for (Map.Entry<String, Value> entry : v1Map.entrySet()) {
+            resultMap.put(entry.getKey(), entry.getValue());
+        }
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeNewPropertiesCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeNewPropertiesCombiner.java
@@ -37,14 +37,18 @@ public class MergeNewPropertiesCombiner implements PropertiesCombiner {
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
         E.checkArgumentNotNull(result,
                                "The combine parameter result can't be null");
+        E.checkState(v1 != result && v2 != result,
+                     "The combine parameter result can't same with v1 or v2");
+
+        result.clear();
+
+        Map<String, Value> v1Map = v1.get();
+        for (Map.Entry<String, Value> entry : v1Map.entrySet()) {
+            result.put(entry.getKey(), entry.getValue());
+        }
         Map<String, Value> v2Map = v2.get();
         for (Map.Entry<String, Value> entry : v2Map.entrySet()) {
-             v1.putIfAbsent(entry.getKey(), entry.getValue());
-        }
-        Map<String, Value> v1Map = v1.get();
-        Map<String, Value> resultMap = result.get();
-        for (Map.Entry<String, Value> entry : v1Map.entrySet()) {
-            resultMap.put(entry.getKey(), entry.getValue());
+             result.putIfAbsent(entry.getKey(), entry.getValue());
         }
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeOldPropertiesCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeOldPropertiesCombiner.java
@@ -37,14 +37,18 @@ public class MergeOldPropertiesCombiner implements PropertiesCombiner {
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
         E.checkArgumentNotNull(result,
                                "The combine parameter result can't be null");
+        E.checkState(v1 != result && v2 != result,
+                     "The combine parameter result can't same with v1 or v2");
+
+        result.clear();
+
+        Map<String, Value> v2Map = v2.get();
+        for (Map.Entry<String, Value> entry : v2Map.entrySet()) {
+            result.put(entry.getKey(), entry.getValue());
+        }
         Map<String, Value> v1Map = v1.get();
         for (Map.Entry<String, Value> entry : v1Map.entrySet()) {
-            v2.putIfAbsent(entry.getKey(), entry.getValue());
-        }
-        Map<String, Value> v2Map = v2.get();
-        Map<String, Value> resultMap = result.get();
-        for (Map.Entry<String, Value> entry : v2Map.entrySet()) {
-            resultMap.put(entry.getKey(), entry.getValue());
+            result.putIfAbsent(entry.getKey(), entry.getValue());
         }
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeOldPropertiesCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeOldPropertiesCombiner.java
@@ -37,8 +37,9 @@ public class MergeOldPropertiesCombiner implements PropertiesCombiner {
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
         E.checkArgumentNotNull(result,
                                "The combine parameter result can't be null");
-        E.checkState(v1 != result && v2 != result,
-                     "The combine parameter result can't same with v1 or v2");
+        E.checkArgument(v1 != result && v2 != result,
+                        "The combine parameter result " +
+                        "can't same with v1 or v2");
 
         result.clear();
 

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeOldPropertiesCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeOldPropertiesCombiner.java
@@ -28,17 +28,23 @@ import com.baidu.hugegraph.util.E;
 public class MergeOldPropertiesCombiner implements PropertiesCombiner {
 
     /**
-     * Merge properties v1 into v2. If a property exists in both v1 and v2,
-     * remain the value in v2.
+     * Merge properties v1 and v2 into result. If a property exists in both v1
+     * and v2, remain the value in v2.
      */
     @Override
-    public Properties combine(Properties v1, Properties v2) {
+    public void combine(Properties v1, Properties v2, Properties result) {
         E.checkArgumentNotNull(v1, "The combine parameter v1 can't be null");
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
+        E.checkArgumentNotNull(result,
+                               "The combine parameter result can't be null");
         Map<String, Value> v1Map = v1.get();
         for (Map.Entry<String, Value> entry : v1Map.entrySet()) {
             v2.putIfAbsent(entry.getKey(), entry.getValue());
         }
-        return v2;
+        Map<String, Value> v2Map = v2.get();
+        Map<String, Value> resultMap = result.get();
+        for (Map.Entry<String, Value> entry : v2Map.entrySet()) {
+            resultMap.put(entry.getKey(), entry.getValue());
+        }
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/OverwriteCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/OverwriteCombiner.java
@@ -19,14 +19,17 @@
 
 package com.baidu.hugegraph.computer.core.combiner;
 
+import com.baidu.hugegraph.computer.core.graph.value.Value;
 import com.baidu.hugegraph.util.E;
 
-public class OverwriteCombiner<T> implements Combiner<T> {
+public class OverwriteCombiner<T extends Value> implements Combiner<T> {
 
     @Override
-    public T combine(T v1, T v2) {
+    public void combine(T v1, T v2, T result) {
         E.checkArgumentNotNull(v1, "The combine parameter v1 can't be null");
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
-        return v2;
+        E.checkArgumentNotNull(result,
+                               "The combine parameter result can't be null");
+        result.assign(v2);
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/OverwritePropertiesCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/OverwritePropertiesCombiner.java
@@ -19,10 +19,7 @@
 
 package com.baidu.hugegraph.computer.core.combiner;
 
-import java.util.Map;
-
 import com.baidu.hugegraph.computer.core.graph.properties.Properties;
-import com.baidu.hugegraph.computer.core.graph.value.Value;
 import com.baidu.hugegraph.util.E;
 
 public class OverwritePropertiesCombiner implements PropertiesCombiner {
@@ -33,10 +30,10 @@ public class OverwritePropertiesCombiner implements PropertiesCombiner {
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
         E.checkArgumentNotNull(result,
                                "The combine parameter result can't be null");
+        E.checkState(v1 != result && v2 != result,
+                     "The combine parameter result can't same with v1 or v2");
+
         result.clear();
-        Map<String, Value> v2Map = v2.get();
-        for (Map.Entry<String, Value> entry : v2Map.entrySet()) {
-            result.put(entry.getKey(), entry.getValue());
-        }
+        result.putAll(v2.get());
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/OverwritePropertiesCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/OverwritePropertiesCombiner.java
@@ -30,8 +30,10 @@ public class OverwritePropertiesCombiner implements PropertiesCombiner {
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
         E.checkArgumentNotNull(result,
                                "The combine parameter result can't be null");
-        E.checkState(v1 != result && v2 != result,
-                     "The combine parameter result can't same with v1 or v2");
+
+        E.checkArgument(v1 != result && v2 != result,
+                        "The combine parameter result " +
+                        "can't same with v1 or v2");
 
         result.clear();
         result.putAll(v2.get());

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/OverwritePropertiesCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/OverwritePropertiesCombiner.java
@@ -19,37 +19,24 @@
 
 package com.baidu.hugegraph.computer.core.combiner;
 
-import java.util.Iterator;
+import java.util.Map;
 
+import com.baidu.hugegraph.computer.core.graph.properties.Properties;
 import com.baidu.hugegraph.computer.core.graph.value.Value;
+import com.baidu.hugegraph.util.E;
 
-public interface Combiner<T> {
+public class OverwritePropertiesCombiner implements PropertiesCombiner {
 
-    /**
-     * @return The name of the combiner.
-     * @return class name by default.
-     */
-    default String name() {
-        return this.getClass().getName();
-    }
-
-    /**
-     * Combine v1 and v2 to result. The combined value may
-     * take use v1 or v2. The value of v1 and v2 may be updated. Should not
-     * use v1 and v2 after combine them.
-     */
-    void combine(T v1, T v2, T result);
-
-    @SuppressWarnings("unchecked")
-    static <T extends Value> T combineAll(Combiner<T> combiner,
-                                          Iterator<T> values) {
-        if (!values.hasNext()) {
-            return null;
+    @Override
+    public void combine(Properties v1, Properties v2, Properties result) {
+        E.checkArgumentNotNull(v1, "The combine parameter v1 can't be null");
+        E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
+        E.checkArgumentNotNull(result,
+                               "The combine parameter result can't be null");
+        result.clear();
+        Map<String, Value> v2Map = v2.get();
+        for (Map.Entry<String, Value> entry : v2Map.entrySet()) {
+            result.put(entry.getKey(), entry.getValue());
         }
-        T result = (T) values.next().copy();
-        while (values.hasNext()) {
-            combiner.combine(result, values.next(), result);
-        }
-        return result;
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/ValueMaxCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/ValueMaxCombiner.java
@@ -25,13 +25,15 @@ import com.baidu.hugegraph.util.E;
 public class ValueMaxCombiner<T extends Value> implements Combiner<T> {
 
     @Override
-    public T combine(T v1, T v2) {
+    public void combine(T v1, T v2, T result) {
         E.checkArgumentNotNull(v1, "The combine parameter v1 can't be null");
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
+        E.checkArgumentNotNull(result,
+                               "The combine parameter result can't be null");
         if (v1.compareTo(v2) >= 0) {
-            return v1;
+            result.assign(v1);
         } else {
-            return v2;
+            result.assign(v2);
         }
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/ValueMinCombiner.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/combiner/ValueMinCombiner.java
@@ -25,13 +25,15 @@ import com.baidu.hugegraph.util.E;
 public class ValueMinCombiner<T extends Value> implements Combiner<T> {
 
     @Override
-    public T combine(T v1, T v2) {
+    public void combine(T v1, T v2, T result) {
         E.checkArgumentNotNull(v1, "The combine parameter v1 can't be null");
         E.checkArgumentNotNull(v2, "The combine parameter v2 can't be null");
+        E.checkArgumentNotNull(result,
+                               "The combine parameter result can't be null");
         if (v1.compareTo(v2) <= 0) {
-            return v1;
+            result.assign(v1);
         } else {
-            return v2;
+            result.assign(v2);
         }
     }
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/graph/properties/Properties.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/graph/properties/Properties.java
@@ -36,4 +36,6 @@ public interface Properties extends Readable, Writable {
     void putIfAbsent(String key, Value value);
 
     int size();
+
+    void clear();
 }

--- a/computer-api/src/main/java/com/baidu/hugegraph/computer/core/graph/properties/Properties.java
+++ b/computer-api/src/main/java/com/baidu/hugegraph/computer/core/graph/properties/Properties.java
@@ -35,6 +35,8 @@ public interface Properties extends Readable, Writable {
 
     void putIfAbsent(String key, Value value);
 
+    void putAll(Map<String, Value> kvs);
+
     int size();
 
     void clear();

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/aggregator/DefaultAggregator.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/aggregator/DefaultAggregator.java
@@ -103,7 +103,7 @@ public class DefaultAggregator<V extends Value> implements Aggregator<V> {
 
     private void combineAndSwapIfNeeded(V localValue, V thisValue) {
         this.combiner.combine(localValue, thisValue, thisValue);
-        this.localValue.set(thisValue);
+        localValue.assign(thisValue);
     }
 
     @Override

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/aggregator/DefaultAggregator.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/aggregator/DefaultAggregator.java
@@ -66,7 +66,7 @@ public class DefaultAggregator<V extends Value> implements Aggregator<V> {
     @Override
     public void aggregateValue(V value) {
         this.checkValue(value);
-        this.value = this.combiner.combine(value, this.value);
+        this.combiner.combine(value, this.value, this.value);
     }
 
     @Override
@@ -102,14 +102,8 @@ public class DefaultAggregator<V extends Value> implements Aggregator<V> {
     }
 
     private void combineAndSwapIfNeeded(V localValue, V thisValue) {
-        // TODO: call combine(localValue, thisValue, <output>thisValue)
-        V tmp = this.combiner.combine(localValue, thisValue);
-        if (tmp == localValue) {
-            this.localValue.set(thisValue);
-            this.value = tmp;
-        } else {
-            assert tmp == thisValue;
-        }
+        this.combiner.combine(localValue, thisValue, thisValue);
+        this.localValue.set(thisValue);
     }
 
     @Override

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/combiner/AbstractPointerCombiner.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/combiner/AbstractPointerCombiner.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.computer.core.combiner;
+
+import java.util.function.Supplier;
+
+import com.baidu.hugegraph.computer.core.common.Constants;
+import com.baidu.hugegraph.computer.core.common.exception.ComputerException;
+import com.baidu.hugegraph.computer.core.io.BytesOutput;
+import com.baidu.hugegraph.computer.core.io.IOFactory;
+import com.baidu.hugegraph.computer.core.io.RandomAccessInput;
+import com.baidu.hugegraph.computer.core.io.Readable;
+import com.baidu.hugegraph.computer.core.io.Writable;
+import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.InlinePointer;
+import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
+
+public abstract class AbstractPointerCombiner<T extends Readable & Writable>
+                implements PointerCombiner {
+
+    protected T v1;
+    protected T v2;
+    protected T result;
+    protected Combiner<T> combiner;
+    protected BytesOutput output;
+
+    public AbstractPointerCombiner(Supplier<T> supplier, Combiner<T> combiner) {
+        this.v1 = supplier.get();
+        this.v2 = supplier.get();
+        this.result = supplier.get();
+        this.combiner = combiner;
+        this.output = IOFactory.createBytesOutput(Constants.SMALL_BUF_SIZE);
+    }
+
+    public Pointer combine(Pointer v1, Pointer v2) {
+        try {
+            RandomAccessInput input1 = v1.input();
+            RandomAccessInput input2 = v2.input();
+            input1.seek(v1.offset());
+            input2.seek(v2.offset());
+
+            this.v1.read(input1);
+            this.v2.read(input2);
+            this.combiner.combine(this.v1, this.v2, this.result);
+
+            this.output.seek(0L);
+            this.result.write(this.output);
+            return new InlinePointer(this.output.buffer(),
+                                     this.output.position());
+        } catch (Exception e) {
+            throw new ComputerException(
+                    "Failed to combine pointer1(offset=%s, length=%s) and " +
+                    "pointer2(offset=%s, length=%s)'",
+                    e, v1.offset(), v1.length(), v2.offset(), v2.length());
+        }
+    }
+}

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/combiner/EdgeValueCombiner.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/combiner/EdgeValueCombiner.java
@@ -17,28 +17,18 @@
  * under the License.
  */
 
-package com.baidu.hugegraph.computer.core.sort.flusher;
+package com.baidu.hugegraph.computer.core.combiner;
 
-import java.io.IOException;
+import com.baidu.hugegraph.computer.core.common.ComputerContext;
+import com.baidu.hugegraph.computer.core.config.ComputerOptions;
+import com.baidu.hugegraph.computer.core.graph.properties.Properties;
 
-import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
-import com.baidu.hugegraph.computer.core.io.RandomAccessOutput;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.KvEntry;
+public class EdgeValueCombiner extends AbstractPointerCombiner<Properties> {
 
-public class CombineKvInnerSortFlusher extends CombinableSorterFlusher
-                                       implements InnerSortFlusher {
-
-    private final RandomAccessOutput output;
-
-    public CombineKvInnerSortFlusher(RandomAccessOutput output,
-                                     PointerCombiner combiner) {
-        super(combiner);
-        this.output = output;
-    }
-
-    @Override
-    protected void writeKvEntry(KvEntry entry) throws IOException {
-        entry.key().write(this.output);
-        entry.value().write(this.output);
+    public EdgeValueCombiner(ComputerContext context) {
+        super(() -> {
+            return context.graphFactory().createProperties();
+        }, context.config().createObject(
+                   ComputerOptions.WORKER_EDGE_PROPERTIES_COMBINER_CLASS));
     }
 }

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/combiner/MessageValueCombiner.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/combiner/MessageValueCombiner.java
@@ -17,28 +17,20 @@
  * under the License.
  */
 
-package com.baidu.hugegraph.computer.core.sort.flusher;
+package com.baidu.hugegraph.computer.core.combiner;
 
-import java.io.IOException;
+import com.baidu.hugegraph.computer.core.common.ComputerContext;
+import com.baidu.hugegraph.computer.core.config.ComputerOptions;
+import com.baidu.hugegraph.computer.core.graph.value.Value;
 
-import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
-import com.baidu.hugegraph.computer.core.io.RandomAccessOutput;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.KvEntry;
+public class MessageValueCombiner extends AbstractPointerCombiner<Value> {
 
-public class CombineKvInnerSortFlusher extends CombinableSorterFlusher
-                                       implements InnerSortFlusher {
-
-    private final RandomAccessOutput output;
-
-    public CombineKvInnerSortFlusher(RandomAccessOutput output,
-                                     PointerCombiner combiner) {
-        super(combiner);
-        this.output = output;
-    }
-
-    @Override
-    protected void writeKvEntry(KvEntry entry) throws IOException {
-        entry.key().write(this.output);
-        entry.value().write(this.output);
+    public MessageValueCombiner(ComputerContext context) {
+        super(() -> {
+            return context.config()
+                          .createObject(
+                           ComputerOptions.ALGORITHM_MESSAGE_CLASS);
+        }, context.config().createObject(
+                            ComputerOptions.WORKER_COMBINER_CLASS));
     }
 }

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/combiner/PointerCombiner.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/combiner/PointerCombiner.java
@@ -1,69 +1,8 @@
-/*
- * Copyright 2017 HugeGraph Authors
- *
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
 package com.baidu.hugegraph.computer.core.combiner;
 
-import com.baidu.hugegraph.computer.core.common.Constants;
-import com.baidu.hugegraph.computer.core.common.exception.ComputerException;
-import com.baidu.hugegraph.computer.core.io.BytesOutput;
-import com.baidu.hugegraph.computer.core.io.IOFactory;
-import com.baidu.hugegraph.computer.core.io.RandomAccessInput;
-import com.baidu.hugegraph.computer.core.io.Readable;
-import com.baidu.hugegraph.computer.core.io.Writable;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.InlinePointer;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
 
-public class PointerCombiner<V extends Readable & Writable> {
+public interface PointerCombiner {
 
-    private final V v1;
-    private final V v2;
-    private final V result;
-    private final Combiner<V> combiner;
-    private final BytesOutput bytesOutput;
-
-    public PointerCombiner(V v1, V v2, V result, Combiner<V> combiner) {
-        this.v1 = v1;
-        this.v2 = v2;
-        this.result = result;
-        this.combiner = combiner;
-        this.bytesOutput = IOFactory.createBytesOutput(
-                           Constants.SMALL_BUF_SIZE);
-    }
-
-    public Pointer combine(Pointer v1, Pointer v2) {
-        try {
-            RandomAccessInput input1 = v1.input();
-            RandomAccessInput input2 = v2.input();
-            input1.seek(v1.offset());
-            input2.seek(v2.offset());
-            this.v1.read(input1);
-            this.v2.read(input2);
-            this.combiner.combine(this.v1, this.v2, this.result);
-            this.bytesOutput.seek(0L);
-            this.result.write(this.bytesOutput);
-            return new InlinePointer(this.bytesOutput.buffer(),
-                                     this.bytesOutput.position());
-        } catch (Exception e) {
-            throw new ComputerException(
-                      "Failed to combine pointer1(offset=%s, length=%s) and" +
-                      " pointer2(offset=%s, length=%s)'",
-                      e, v1.offset(), v1.length(), v2.offset(), v2.length());
-        }
-    }
+    Pointer combine(Pointer v1, Pointer v2);
 }

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/combiner/PointerCombiner.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/combiner/PointerCombiner.java
@@ -29,23 +29,23 @@ import com.baidu.hugegraph.computer.core.io.Writable;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.InlinePointer;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
 
-public class PointerCombiner<V extends Readable & Writable>
-       implements Combiner<Pointer> {
+public class PointerCombiner<V extends Readable & Writable> {
 
     private final V v1;
     private final V v2;
+    private final V result;
     private final Combiner<V> combiner;
     private final BytesOutput bytesOutput;
 
-    public PointerCombiner(V v1, V v2, Combiner<V> combiner) {
+    public PointerCombiner(V v1, V v2, V result, Combiner<V> combiner) {
         this.v1 = v1;
         this.v2 = v2;
+        this.result = result;
         this.combiner = combiner;
         this.bytesOutput = IOFactory.createBytesOutput(
                            Constants.SMALL_BUF_SIZE);
     }
 
-    @Override
     public Pointer combine(Pointer v1, Pointer v2) {
         try {
             RandomAccessInput input1 = v1.input();
@@ -54,9 +54,9 @@ public class PointerCombiner<V extends Readable & Writable>
             input2.seek(v2.offset());
             this.v1.read(input1);
             this.v2.read(input2);
-            V combinedValue = this.combiner.combine(this.v1, this.v2);
+            this.combiner.combine(this.v1, this.v2, this.result);
             this.bytesOutput.seek(0L);
-            combinedValue.write(this.bytesOutput);
+            this.result.write(this.bytesOutput);
             return new InlinePointer(this.bytesOutput.buffer(),
                                      this.bytesOutput.position());
         } catch (Exception e) {

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/combiner/VertexValueCombiner.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/combiner/VertexValueCombiner.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 HugeGraph Authors
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.baidu.hugegraph.computer.core.combiner;
+
+import com.baidu.hugegraph.computer.core.common.ComputerContext;
+import com.baidu.hugegraph.computer.core.common.exception.ComputerException;
+import com.baidu.hugegraph.computer.core.config.ComputerOptions;
+import com.baidu.hugegraph.computer.core.graph.properties.Properties;
+import com.baidu.hugegraph.computer.core.io.RandomAccessInput;
+import com.baidu.hugegraph.computer.core.io.StreamGraphInput;
+import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.InlinePointer;
+import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
+
+public class VertexValueCombiner extends AbstractPointerCombiner<Properties> {
+
+    public VertexValueCombiner(ComputerContext context) {
+        super(() -> {
+            return context.graphFactory().createProperties();
+        }, context.config().createObject(
+           ComputerOptions.WORKER_VERTEX_PROPERTIES_COMBINER_CLASS));
+    }
+
+    @Override
+    public Pointer combine(Pointer v1, Pointer v2) {
+        try {
+            RandomAccessInput input1 = v1.input();
+            RandomAccessInput input2 = v2.input();
+            input1.seek(v1.offset());
+            input2.seek(v2.offset());
+            String label1 = StreamGraphInput.readLabel(input1);
+            String label2 = StreamGraphInput.readLabel(input1);
+            assert label1.equals(label2);
+
+            this.v1.read(input1);
+            this.v2.read(input2);
+            this.combiner.combine(this.v1, this.v2, this.result);
+
+            this.output.seek(0L);
+            this.output.writeUTF(label1);
+            this.result.write(this.output);
+            return new InlinePointer(this.output.buffer(),
+                                     this.output.position());
+        } catch (Exception e) {
+            throw new ComputerException(
+                    "Failed to combine pointer1(offset=%s, length=%s) and " +
+                    "pointer2(offset=%s, length=%s)'",
+                    e, v1.offset(), v1.length(), v2.offset(), v2.length());
+        }
+    }
+}

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/combiner/VertexValueCombiner.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/combiner/VertexValueCombiner.java
@@ -45,7 +45,7 @@ public class VertexValueCombiner extends AbstractPointerCombiner<Properties> {
             input1.seek(v1.offset());
             input2.seek(v2.offset());
             String label1 = StreamGraphInput.readLabel(input1);
-            String label2 = StreamGraphInput.readLabel(input1);
+            String label2 = StreamGraphInput.readLabel(input2);
             assert label1.equals(label2);
 
             this.v1.read(input1);

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/compute/input/EdgesInput.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/compute/input/EdgesInput.java
@@ -218,7 +218,6 @@ public class EdgesInput {
                     // Only use targetId as subKey, use props as subValue
                     edge.targetId(StreamGraphInput.readId(in));
                     // Read subValue
-                    edge.label(StreamGraphInput.readLabel(in));
                     Properties props = this.graphFactory.createProperties();
                     props.read(in);
                     edge.properties(props);

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/config/ComputerOptions.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/config/ComputerOptions.java
@@ -27,7 +27,7 @@ import static com.baidu.hugegraph.config.OptionChecker.positiveInt;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import com.baidu.hugegraph.computer.core.combiner.OverwriteCombiner;
+import com.baidu.hugegraph.computer.core.combiner.OverwritePropertiesCombiner;
 import com.baidu.hugegraph.computer.core.graph.partition.HashPartitioner;
 import com.baidu.hugegraph.computer.core.input.filter.DefaultInputFilter;
 import com.baidu.hugegraph.computer.core.master.DefaultMasterComputation;
@@ -442,7 +442,7 @@ public class ComputerOptions extends OptionHolder {
                     "The combiner can combine several properties of the same " +
                     "vertex into one properties at inputstep.",
                     disallowEmpty(),
-                    OverwriteCombiner.class
+                    OverwritePropertiesCombiner.class
             );
 
     public static final ConfigOption<Class<?>>
@@ -452,7 +452,7 @@ public class ComputerOptions extends OptionHolder {
                     "The combiner can combine several properties of the same " +
                     "edge into one properties at inputstep.",
                     disallowEmpty(),
-                    OverwriteCombiner.class
+                    OverwritePropertiesCombiner.class
             );
 
     public static final ConfigOption<Long> WORKER_RECEIVED_BUFFERS_BYTES_LIMIT =

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/graph/properties/DefaultProperties.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/graph/properties/DefaultProperties.java
@@ -67,6 +67,11 @@ public class DefaultProperties implements Properties {
         this.keyValues.putIfAbsent(key, value);
     }
 
+    @Override
+    public void putAll(Map<String, Value> kvs) {
+        this.keyValues.putAll(kvs);
+    }
+
     public int size() {
         return this.keyValues.size();
     }

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/graph/properties/DefaultProperties.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/graph/properties/DefaultProperties.java
@@ -72,6 +72,11 @@ public class DefaultProperties implements Properties {
     }
 
     @Override
+    public void clear() {
+        this.keyValues.clear();
+    }
+
+    @Override
     public void read(RandomAccessInput in) throws IOException {
         this.keyValues.clear();
         int size = in.readInt();

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/io/StreamGraphInput.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/io/StreamGraphInput.java
@@ -78,7 +78,6 @@ public class StreamGraphInput implements GraphComputeInput {
                 reader.readSubKv(in -> {
                     edge.targetId(readId(in));
                 }, in -> {
-                    edge.label(readLabel(in));
                     edge.properties(readProperties(in));
                 });
                 vertex.addEdge(edge);

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/io/StreamGraphOutput.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/io/StreamGraphOutput.java
@@ -68,7 +68,6 @@ public class StreamGraphOutput implements GraphComputeOutput {
                 writer.writeSubKv(out -> {
                     this.writeId(out, edge.targetId());
                 }, out -> {
-                    this.writeLabel(out, edge.label());
                     this.writeProperties(out, edge.properties());
                 });
             }

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/edge/EdgeMessageRecvPartition.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/edge/EdgeMessageRecvPartition.java
@@ -50,9 +50,8 @@ public class EdgeMessageRecvPartition extends MessageRecvPartition {
                 ComputerOptions.WORKER_EDGE_PROPERTIES_COMBINER_CLASS);
 
         /*
-         * If propertiesCombiner is OverwriteCombiner, just remain the
-         * second, no need to deserialize the properties and then serialize
-         * the second properties.
+         * If propCombiner is OverwritePropertiesCombiner, also need to
+         * deserialize the properties now.
          */
         GraphFactory graphFactory = context.graphFactory();
         Properties v1 = graphFactory.createProperties();

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/edge/EdgeMessageRecvPartition.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/edge/EdgeMessageRecvPartition.java
@@ -19,12 +19,11 @@
 
 package com.baidu.hugegraph.computer.core.receiver.edge;
 
-import com.baidu.hugegraph.computer.core.combiner.Combiner;
-import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
+import com.baidu.hugegraph.computer.core.combiner.EdgeValueCombiner;
+import com.baidu.hugegraph.computer.core.combiner.AbstractPointerCombiner;
 import com.baidu.hugegraph.computer.core.common.ComputerContext;
 import com.baidu.hugegraph.computer.core.config.ComputerOptions;
 import com.baidu.hugegraph.computer.core.config.Config;
-import com.baidu.hugegraph.computer.core.graph.GraphFactory;
 import com.baidu.hugegraph.computer.core.graph.properties.Properties;
 import com.baidu.hugegraph.computer.core.network.message.MessageType;
 import com.baidu.hugegraph.computer.core.receiver.MessageRecvPartition;
@@ -43,23 +42,13 @@ public class EdgeMessageRecvPartition extends MessageRecvPartition {
                                     SuperstepFileGenerator fileGenerator,
                                     SortManager sortManager) {
         super(context.config(), fileGenerator, sortManager, true);
+
         Config config = context.config();
         int flushThreshold = config.get(
                              ComputerOptions.INPUT_MAX_EDGES_IN_ONE_VERTEX);
-        Combiner<Properties> propCombiner = config.createObject(
-                ComputerOptions.WORKER_EDGE_PROPERTIES_COMBINER_CLASS);
+        AbstractPointerCombiner<Properties>
+                combiner = new EdgeValueCombiner(context);
 
-        /*
-         * If propCombiner is OverwritePropertiesCombiner, also need to
-         * deserialize the properties now.
-         */
-        GraphFactory graphFactory = context.graphFactory();
-        Properties v1 = graphFactory.createProperties();
-        Properties v2 = graphFactory.createProperties();
-        Properties result = graphFactory.createProperties();
-        PointerCombiner<Properties> combiner = new PointerCombiner<>(
-                                                   v1, v2, result,
-                                                   propCombiner);
         this.flusher = new CombineSubKvOuterSortFlusher(combiner,
                                                         flushThreshold);
     }

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/edge/EdgeMessageRecvPartition.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/edge/EdgeMessageRecvPartition.java
@@ -20,11 +20,10 @@
 package com.baidu.hugegraph.computer.core.receiver.edge;
 
 import com.baidu.hugegraph.computer.core.combiner.EdgeValueCombiner;
-import com.baidu.hugegraph.computer.core.combiner.AbstractPointerCombiner;
+import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.common.ComputerContext;
 import com.baidu.hugegraph.computer.core.config.ComputerOptions;
 import com.baidu.hugegraph.computer.core.config.Config;
-import com.baidu.hugegraph.computer.core.graph.properties.Properties;
 import com.baidu.hugegraph.computer.core.network.message.MessageType;
 import com.baidu.hugegraph.computer.core.receiver.MessageRecvPartition;
 import com.baidu.hugegraph.computer.core.sort.flusher.CombineSubKvOuterSortFlusher;
@@ -46,8 +45,7 @@ public class EdgeMessageRecvPartition extends MessageRecvPartition {
         Config config = context.config();
         int flushThreshold = config.get(
                              ComputerOptions.INPUT_MAX_EDGES_IN_ONE_VERTEX);
-        AbstractPointerCombiner<Properties>
-                combiner = new EdgeValueCombiner(context);
+        PointerCombiner combiner = new EdgeValueCombiner(context);
 
         this.flusher = new CombineSubKvOuterSortFlusher(combiner,
                                                         flushThreshold);

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/edge/EdgeMessageRecvPartition.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/edge/EdgeMessageRecvPartition.java
@@ -20,7 +20,6 @@
 package com.baidu.hugegraph.computer.core.receiver.edge;
 
 import com.baidu.hugegraph.computer.core.combiner.Combiner;
-import com.baidu.hugegraph.computer.core.combiner.OverwriteCombiner;
 import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.common.ComputerContext;
 import com.baidu.hugegraph.computer.core.config.ComputerOptions;
@@ -33,7 +32,6 @@ import com.baidu.hugegraph.computer.core.sort.flusher.CombineSubKvOuterSortFlush
 import com.baidu.hugegraph.computer.core.sort.flusher.OuterSortFlusher;
 import com.baidu.hugegraph.computer.core.sort.sorting.SortManager;
 import com.baidu.hugegraph.computer.core.store.SuperstepFileGenerator;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
 
 public class EdgeMessageRecvPartition extends MessageRecvPartition {
 
@@ -56,16 +54,13 @@ public class EdgeMessageRecvPartition extends MessageRecvPartition {
          * second, no need to deserialize the properties and then serialize
          * the second properties.
          */
-        Combiner<Pointer> combiner;
-        if (propCombiner instanceof OverwriteCombiner) {
-            combiner = new OverwriteCombiner<>();
-        } else {
-            GraphFactory graphFactory = context.graphFactory();
-            Properties v1 = graphFactory.createProperties();
-            Properties v2 = graphFactory.createProperties();
-
-            combiner = new PointerCombiner<>(v1, v2, propCombiner);
-        }
+        GraphFactory graphFactory = context.graphFactory();
+        Properties v1 = graphFactory.createProperties();
+        Properties v2 = graphFactory.createProperties();
+        Properties result = graphFactory.createProperties();
+        PointerCombiner<Properties> combiner = new PointerCombiner<>(
+                                                   v1, v2, result,
+                                                   propCombiner);
         this.flusher = new CombineSubKvOuterSortFlusher(combiner,
                                                         flushThreshold);
     }

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/message/ComputeMessageRecvPartition.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/message/ComputeMessageRecvPartition.java
@@ -21,7 +21,7 @@ package com.baidu.hugegraph.computer.core.receiver.message;
 
 import com.baidu.hugegraph.computer.core.combiner.Combiner;
 import com.baidu.hugegraph.computer.core.combiner.MessageValueCombiner;
-import com.baidu.hugegraph.computer.core.combiner.AbstractPointerCombiner;
+import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.common.ComputerContext;
 import com.baidu.hugegraph.computer.core.config.ComputerOptions;
 import com.baidu.hugegraph.computer.core.config.Config;
@@ -51,8 +51,7 @@ public class ComputeMessageRecvPartition extends MessageRecvPartition {
         if (combiner == null) {
             this.flusher = new KvOuterSortFlusher();
         } else {
-            AbstractPointerCombiner<Value> pointerCombiner =
-                                   new MessageValueCombiner(context);
+            PointerCombiner pointerCombiner = new MessageValueCombiner(context);
             this.flusher = new CombineKvOuterSortFlusher(pointerCombiner);
         }
     }

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/message/ComputeMessageRecvPartition.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/message/ComputeMessageRecvPartition.java
@@ -20,7 +20,8 @@
 package com.baidu.hugegraph.computer.core.receiver.message;
 
 import com.baidu.hugegraph.computer.core.combiner.Combiner;
-import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
+import com.baidu.hugegraph.computer.core.combiner.MessageValueCombiner;
+import com.baidu.hugegraph.computer.core.combiner.AbstractPointerCombiner;
 import com.baidu.hugegraph.computer.core.common.ComputerContext;
 import com.baidu.hugegraph.computer.core.config.ComputerOptions;
 import com.baidu.hugegraph.computer.core.config.Config;
@@ -50,12 +51,8 @@ public class ComputeMessageRecvPartition extends MessageRecvPartition {
         if (combiner == null) {
             this.flusher = new KvOuterSortFlusher();
         } else {
-            Value v1 = config.createObject(
-                       ComputerOptions.ALGORITHM_MESSAGE_CLASS);
-            Value v2 = v1.copy();
-            Value result = v1.copy();
-            PointerCombiner<Value> pointerCombiner = new PointerCombiner<>(
-                                                     v1, v2, result, combiner);
+            AbstractPointerCombiner<Value> pointerCombiner =
+                                   new MessageValueCombiner(context);
             this.flusher = new CombineKvOuterSortFlusher(pointerCombiner);
         }
     }

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/message/ComputeMessageRecvPartition.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/message/ComputeMessageRecvPartition.java
@@ -53,8 +53,9 @@ public class ComputeMessageRecvPartition extends MessageRecvPartition {
             Value v1 = config.createObject(
                        ComputerOptions.ALGORITHM_MESSAGE_CLASS);
             Value v2 = v1.copy();
+            Value result = v1.copy();
             PointerCombiner<Value> pointerCombiner = new PointerCombiner<>(
-                                                     v1, v2, combiner);
+                                                     v1, v2, result, combiner);
             this.flusher = new CombineKvOuterSortFlusher(pointerCombiner);
         }
     }

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/vertex/VertexMessageRecvPartition.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/vertex/VertexMessageRecvPartition.java
@@ -19,10 +19,9 @@
 
 package com.baidu.hugegraph.computer.core.receiver.vertex;
 
-import com.baidu.hugegraph.computer.core.combiner.AbstractPointerCombiner;
+import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.combiner.VertexValueCombiner;
 import com.baidu.hugegraph.computer.core.common.ComputerContext;
-import com.baidu.hugegraph.computer.core.graph.properties.Properties;
 import com.baidu.hugegraph.computer.core.network.message.MessageType;
 import com.baidu.hugegraph.computer.core.receiver.MessageRecvPartition;
 import com.baidu.hugegraph.computer.core.sort.flusher.CombineKvOuterSortFlusher;
@@ -41,8 +40,7 @@ public class VertexMessageRecvPartition extends MessageRecvPartition {
                                       SortManager sortManager) {
         super(context.config(), fileGenerator, sortManager, false);
 
-        AbstractPointerCombiner<Properties>
-                combiner = new VertexValueCombiner(context);
+        PointerCombiner combiner = new VertexValueCombiner(context);
 
         this.flusher = new CombineKvOuterSortFlusher(combiner);
     }

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/vertex/VertexMessageRecvPartition.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/vertex/VertexMessageRecvPartition.java
@@ -20,7 +20,6 @@
 package com.baidu.hugegraph.computer.core.receiver.vertex;
 
 import com.baidu.hugegraph.computer.core.combiner.Combiner;
-import com.baidu.hugegraph.computer.core.combiner.OverwriteCombiner;
 import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.common.ComputerContext;
 import com.baidu.hugegraph.computer.core.config.ComputerOptions;
@@ -33,7 +32,6 @@ import com.baidu.hugegraph.computer.core.sort.flusher.CombineKvOuterSortFlusher;
 import com.baidu.hugegraph.computer.core.sort.flusher.OuterSortFlusher;
 import com.baidu.hugegraph.computer.core.sort.sorting.SortManager;
 import com.baidu.hugegraph.computer.core.store.SuperstepFileGenerator;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
 
 public class VertexMessageRecvPartition extends MessageRecvPartition {
 
@@ -46,24 +44,21 @@ public class VertexMessageRecvPartition extends MessageRecvPartition {
                                       SortManager sortManager) {
         super(context.config(), fileGenerator, sortManager, false);
         Config config = context.config();
+        /*
+         * TODO: need improve because properties need to deserialize even if
+         *  properties combiner is OverwritePropertiesCombiner
+         */
         Combiner<Properties> propertiesCombiner = config.createObject(
                 ComputerOptions.WORKER_VERTEX_PROPERTIES_COMBINER_CLASS);
 
-        /*
-         * If propertiesCombiner is OverwriteCombiner, just remain the
-         * second, no need to deserialize the properties and then serialize
-         * the second properties.
-         */
-        Combiner<Pointer> combiner;
-        if (propertiesCombiner instanceof OverwriteCombiner) {
-            combiner = new OverwriteCombiner<>();
-        } else {
-            GraphFactory graphFactory = context.graphFactory();
-            Properties v1 = graphFactory.createProperties();
-            Properties v2 = graphFactory.createProperties();
+        GraphFactory graphFactory = context.graphFactory();
+        Properties v1 = graphFactory.createProperties();
+        Properties v2 = graphFactory.createProperties();
+        Properties result = graphFactory.createProperties();
 
-            combiner = new PointerCombiner<>(v1, v2, propertiesCombiner);
-        }
+        PointerCombiner<Properties> combiner = new PointerCombiner<>(
+                                                   v1, v2, result,
+                                                   propertiesCombiner);
         this.flusher = new CombineKvOuterSortFlusher(combiner);
     }
 

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/vertex/VertexMessageRecvPartition.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/receiver/vertex/VertexMessageRecvPartition.java
@@ -19,12 +19,9 @@
 
 package com.baidu.hugegraph.computer.core.receiver.vertex;
 
-import com.baidu.hugegraph.computer.core.combiner.Combiner;
-import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
+import com.baidu.hugegraph.computer.core.combiner.AbstractPointerCombiner;
+import com.baidu.hugegraph.computer.core.combiner.VertexValueCombiner;
 import com.baidu.hugegraph.computer.core.common.ComputerContext;
-import com.baidu.hugegraph.computer.core.config.ComputerOptions;
-import com.baidu.hugegraph.computer.core.config.Config;
-import com.baidu.hugegraph.computer.core.graph.GraphFactory;
 import com.baidu.hugegraph.computer.core.graph.properties.Properties;
 import com.baidu.hugegraph.computer.core.network.message.MessageType;
 import com.baidu.hugegraph.computer.core.receiver.MessageRecvPartition;
@@ -43,22 +40,10 @@ public class VertexMessageRecvPartition extends MessageRecvPartition {
                                       SuperstepFileGenerator fileGenerator,
                                       SortManager sortManager) {
         super(context.config(), fileGenerator, sortManager, false);
-        Config config = context.config();
-        /*
-         * TODO: need improve because properties need to deserialize even if
-         *  properties combiner is OverwritePropertiesCombiner
-         */
-        Combiner<Properties> propertiesCombiner = config.createObject(
-                ComputerOptions.WORKER_VERTEX_PROPERTIES_COMBINER_CLASS);
 
-        GraphFactory graphFactory = context.graphFactory();
-        Properties v1 = graphFactory.createProperties();
-        Properties v2 = graphFactory.createProperties();
-        Properties result = graphFactory.createProperties();
+        AbstractPointerCombiner<Properties>
+                combiner = new VertexValueCombiner(context);
 
-        PointerCombiner<Properties> combiner = new PointerCombiner<>(
-                                                   v1, v2, result,
-                                                   propertiesCombiner);
         this.flusher = new CombineKvOuterSortFlusher(combiner);
     }
 

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombinableSorterFlusher.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombinableSorterFlusher.java
@@ -30,9 +30,9 @@ import com.baidu.hugegraph.util.E;
 
 public abstract class CombinableSorterFlusher {
 
-    private final PointerCombiner<?> combiner;
+    private final PointerCombiner combiner;
 
-    public CombinableSorterFlusher(PointerCombiner<?> combiner) {
+    public CombinableSorterFlusher(PointerCombiner combiner) {
         this.combiner = combiner;
     }
 

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombinableSorterFlusher.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombinableSorterFlusher.java
@@ -22,7 +22,7 @@ package com.baidu.hugegraph.computer.core.sort.flusher;
 import java.io.IOException;
 import java.util.Iterator;
 
-import com.baidu.hugegraph.computer.core.combiner.Combiner;
+import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.DefaultKvEntry;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.KvEntry;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
@@ -30,9 +30,9 @@ import com.baidu.hugegraph.util.E;
 
 public abstract class CombinableSorterFlusher {
 
-    private final Combiner<Pointer> combiner;
+    private final PointerCombiner<?> combiner;
 
-    public CombinableSorterFlusher(Combiner<Pointer> combiner) {
+    public CombinableSorterFlusher(PointerCombiner<?> combiner) {
         this.combiner = combiner;
     }
 

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombineKvInnerSortFlusher.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombineKvInnerSortFlusher.java
@@ -21,10 +21,9 @@ package com.baidu.hugegraph.computer.core.sort.flusher;
 
 import java.io.IOException;
 
-import com.baidu.hugegraph.computer.core.combiner.Combiner;
+import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.io.RandomAccessOutput;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.KvEntry;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
 
 public class CombineKvInnerSortFlusher extends CombinableSorterFlusher
                                        implements InnerSortFlusher {
@@ -32,7 +31,7 @@ public class CombineKvInnerSortFlusher extends CombinableSorterFlusher
     private final RandomAccessOutput output;
 
     public CombineKvInnerSortFlusher(RandomAccessOutput output,
-                                     Combiner<Pointer> combiner) {
+                                     PointerCombiner<?> combiner) {
         super(combiner);
         this.output = output;
     }

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombineKvOuterSortFlusher.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombineKvOuterSortFlusher.java
@@ -21,10 +21,9 @@ package com.baidu.hugegraph.computer.core.sort.flusher;
 
 import java.io.IOException;
 
-import com.baidu.hugegraph.computer.core.combiner.Combiner;
+import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.buffer.EntryIterator;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.KvEntry;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.file.builder.HgkvDirBuilder;
 
 public class CombineKvOuterSortFlusher extends CombinableSorterFlusher
@@ -32,7 +31,7 @@ public class CombineKvOuterSortFlusher extends CombinableSorterFlusher
 
     private HgkvDirBuilder writer;
 
-    public CombineKvOuterSortFlusher(Combiner<Pointer> combiner) {
+    public CombineKvOuterSortFlusher(PointerCombiner<?> combiner) {
         super(combiner);
     }
 

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombineKvOuterSortFlusher.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombineKvOuterSortFlusher.java
@@ -31,7 +31,7 @@ public class CombineKvOuterSortFlusher extends CombinableSorterFlusher
 
     private HgkvDirBuilder writer;
 
-    public CombineKvOuterSortFlusher(PointerCombiner<?> combiner) {
+    public CombineKvOuterSortFlusher(PointerCombiner combiner) {
         super(combiner);
     }
 

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombineSubKvInnerSortFlusher.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombineSubKvInnerSortFlusher.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import com.baidu.hugegraph.computer.core.combiner.Combiner;
+import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.io.RandomAccessOutput;
 import com.baidu.hugegraph.computer.core.sort.sorting.SortingFactory;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.EntriesUtil;
@@ -37,11 +37,11 @@ import com.baidu.hugegraph.util.E;
 public class CombineSubKvInnerSortFlusher implements InnerSortFlusher {
 
     private final RandomAccessOutput output;
-    private final Combiner<Pointer> combiner;
+    private final PointerCombiner<?> combiner;
     private final int subKvFlushThreshold;
 
     public CombineSubKvInnerSortFlusher(RandomAccessOutput output,
-                                        Combiner<Pointer> combiner,
+                                        PointerCombiner<?> combiner,
                                         int subKvFlushThreshold) {
         this.output = output;
         this.combiner = combiner;
@@ -54,7 +54,7 @@ public class CombineSubKvInnerSortFlusher implements InnerSortFlusher {
     }
 
     @Override
-    public Combiner<Pointer> combiner() {
+    public PointerCombiner<?> combiner() {
         return this.combiner;
     }
 

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombineSubKvInnerSortFlusher.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombineSubKvInnerSortFlusher.java
@@ -37,11 +37,11 @@ import com.baidu.hugegraph.util.E;
 public class CombineSubKvInnerSortFlusher implements InnerSortFlusher {
 
     private final RandomAccessOutput output;
-    private final PointerCombiner<?> combiner;
+    private final PointerCombiner combiner;
     private final int subKvFlushThreshold;
 
     public CombineSubKvInnerSortFlusher(RandomAccessOutput output,
-                                        PointerCombiner<?> combiner,
+                                        PointerCombiner combiner,
                                         int subKvFlushThreshold) {
         this.output = output;
         this.combiner = combiner;
@@ -54,7 +54,7 @@ public class CombineSubKvInnerSortFlusher implements InnerSortFlusher {
     }
 
     @Override
-    public PointerCombiner<?> combiner() {
+    public PointerCombiner combiner() {
         return this.combiner;
     }
 

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombineSubKvOuterSortFlusher.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombineSubKvOuterSortFlusher.java
@@ -21,7 +21,7 @@ package com.baidu.hugegraph.computer.core.sort.flusher;
 
 import java.io.IOException;
 
-import com.baidu.hugegraph.computer.core.combiner.Combiner;
+import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.common.Constants;
 import com.baidu.hugegraph.computer.core.io.BytesOutput;
 import com.baidu.hugegraph.computer.core.io.IOFactory;
@@ -36,12 +36,12 @@ import com.baidu.hugegraph.util.E;
 
 public class CombineSubKvOuterSortFlusher implements OuterSortFlusher {
 
-    private final Combiner<Pointer> combiner;
+    private final PointerCombiner<?> combiner;
     private final BytesOutput output;
     private final int subKvFlushThreshold;
     private int sources;
 
-    public CombineSubKvOuterSortFlusher(Combiner<Pointer> combiner,
+    public CombineSubKvOuterSortFlusher(PointerCombiner<?> combiner,
                                         int subKvFlushThreshold) {
         this.combiner = combiner;
         this.output = IOFactory.createBytesOutput(

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombineSubKvOuterSortFlusher.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/CombineSubKvOuterSortFlusher.java
@@ -36,12 +36,12 @@ import com.baidu.hugegraph.util.E;
 
 public class CombineSubKvOuterSortFlusher implements OuterSortFlusher {
 
-    private final PointerCombiner<?> combiner;
+    private final PointerCombiner combiner;
     private final BytesOutput output;
     private final int subKvFlushThreshold;
     private int sources;
 
-    public CombineSubKvOuterSortFlusher(PointerCombiner<?> combiner,
+    public CombineSubKvOuterSortFlusher(PointerCombiner combiner,
                                         int subKvFlushThreshold) {
         this.combiner = combiner;
         this.output = IOFactory.createBytesOutput(

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/InnerSortFlusher.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/InnerSortFlusher.java
@@ -40,7 +40,7 @@ public interface InnerSortFlusher {
     /**
      * Combine entries with the same key.
      */
-    default PointerCombiner<?> combiner() {
+    default PointerCombiner combiner() {
         throw new NotImplementedException();
     }
 

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/InnerSortFlusher.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/flusher/InnerSortFlusher.java
@@ -24,10 +24,9 @@ import java.util.Iterator;
 
 import org.apache.commons.lang.NotImplementedException;
 
-import com.baidu.hugegraph.computer.core.combiner.Combiner;
+import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.io.RandomAccessOutput;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.KvEntry;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
 
 public interface InnerSortFlusher {
 
@@ -41,7 +40,7 @@ public interface InnerSortFlusher {
     /**
      * Combine entries with the same key.
      */
-    default Combiner<Pointer> combiner() {
+    default PointerCombiner<?> combiner() {
         throw new NotImplementedException();
     }
 

--- a/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/sorting/SortManager.java
+++ b/computer-core/src/main/java/com/baidu/hugegraph/computer/core/sort/sorting/SortManager.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import com.baidu.hugegraph.computer.core.combiner.Combiner;
 import com.baidu.hugegraph.computer.core.combiner.EdgeValueCombiner;
 import com.baidu.hugegraph.computer.core.combiner.MessageValueCombiner;
-import com.baidu.hugegraph.computer.core.combiner.AbstractPointerCombiner;
+import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.combiner.VertexValueCombiner;
 import com.baidu.hugegraph.computer.core.common.ComputerContext;
 import com.baidu.hugegraph.computer.core.common.Constants;
@@ -171,7 +171,7 @@ public abstract class SortManager implements Manager {
     private InnerSortFlusher createSortFlusher(MessageType type,
                                                RandomAccessOutput output,
                                                int flushThreshold) {
-        AbstractPointerCombiner combiner;
+        PointerCombiner combiner;
         boolean needSortSubKv;
 
         switch (type) {
@@ -207,7 +207,7 @@ public abstract class SortManager implements Manager {
         return flusher;
     }
 
-    private AbstractPointerCombiner createMessageCombiner() {
+    private PointerCombiner createMessageCombiner() {
         Config config = this.context.config();
         Combiner<Value> valueCombiner = config.createObject(
                                         ComputerOptions.WORKER_COMBINER_CLASS,

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/DoubleValueSumCombinerTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/DoubleValueSumCombinerTest.java
@@ -32,7 +32,7 @@ public class DoubleValueSumCombinerTest {
         DoubleValueSumCombiner combiner = new DoubleValueSumCombiner();
         for (int i = 1; i <= 10; i++) {
             DoubleValue value = new DoubleValue(i);
-            sum = combiner.combine(sum, value);
+            combiner.combine(sum, value, sum);
         }
         Assert.assertEquals(55.0D, sum.value(), 0.0D);
     }
@@ -43,16 +43,23 @@ public class DoubleValueSumCombinerTest {
         DoubleValue value2 = new DoubleValue(0.0D);
         DoubleValueSumCombiner combiner = new DoubleValueSumCombiner();
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(null, value2);
+            combiner.combine(null, value2, value2);
         }, e -> {
             Assert.assertEquals("The combine parameter v1 can't be null",
                                 e.getMessage());
         });
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(value1, null);
+            combiner.combine(value1, null, value2);
         }, e -> {
             Assert.assertEquals("The combine parameter v2 can't be null",
+                                e.getMessage());
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            combiner.combine(value1, value2, null);
+        }, e -> {
+            Assert.assertEquals("The combine parameter result can't be null",
                                 e.getMessage());
         });
     }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/FloatValueSumCombinerTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/FloatValueSumCombinerTest.java
@@ -32,7 +32,7 @@ public class FloatValueSumCombinerTest {
         FloatValueSumCombiner combiner = new FloatValueSumCombiner();
         for (int i = 1; i <= 10; i++) {
             FloatValue value = new FloatValue(i);
-            sum = combiner.combine(sum, value);
+            combiner.combine(sum, value, sum);
         }
         Assert.assertEquals(55.0D, sum.value(), 0.0D);
     }
@@ -43,16 +43,23 @@ public class FloatValueSumCombinerTest {
         FloatValue value2 = new FloatValue(0.0f);
         FloatValueSumCombiner combiner = new FloatValueSumCombiner();
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(null, value2);
+            combiner.combine(null, value2, value2);
         }, e -> {
             Assert.assertEquals("The combine parameter v1 can't be null",
                                 e.getMessage());
         });
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(value1, null);
+            combiner.combine(value1, null, value2);
         }, e -> {
             Assert.assertEquals("The combine parameter v2 can't be null",
+                                e.getMessage());
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            combiner.combine(value1, value2, null);
+        }, e -> {
+            Assert.assertEquals("The combine parameter result can't be null",
                                 e.getMessage());
         });
     }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/IntValueSumCombinerTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/IntValueSumCombinerTest.java
@@ -32,7 +32,7 @@ public class IntValueSumCombinerTest {
         IntValueSumCombiner combiner = new IntValueSumCombiner();
         for (int i = 1; i <= 10; i++) {
             IntValue value = new IntValue(i);
-            sum = combiner.combine(sum, value);
+            combiner.combine(sum, value, sum);
         }
         Assert.assertEquals(55, sum.value());
     }
@@ -43,16 +43,23 @@ public class IntValueSumCombinerTest {
         IntValue value2 = new IntValue(2);
         IntValueSumCombiner combiner = new IntValueSumCombiner();
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(null, value2);
+            combiner.combine(null, value2, value2);
         }, e -> {
             Assert.assertEquals("The combine parameter v1 can't be null",
                                 e.getMessage());
         });
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(value1, null);
+            combiner.combine(value1, null, value2);
         }, e -> {
             Assert.assertEquals("The combine parameter v2 can't be null",
+                                e.getMessage());
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            combiner.combine(value1, value2, null);
+        }, e -> {
+            Assert.assertEquals("The combine parameter result can't be null",
                                 e.getMessage());
         });
     }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/LongValueSumCombinerTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/LongValueSumCombinerTest.java
@@ -32,7 +32,7 @@ public class LongValueSumCombinerTest {
         LongValueSumCombiner combiner = new LongValueSumCombiner();
         for (int i = 1; i <= 10; i++) {
             LongValue value = new LongValue(i);
-            sum = combiner.combine(sum, value);
+            combiner.combine(sum, value, sum);
         }
         Assert.assertEquals(55L, sum.value());
     }
@@ -43,16 +43,23 @@ public class LongValueSumCombinerTest {
         LongValue value2 = new LongValue(2L);
         LongValueSumCombiner combiner = new LongValueSumCombiner();
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(null, value2);
+            combiner.combine(null, value2, value2);
         }, e -> {
             Assert.assertEquals("The combine parameter v1 can't be null",
                                 e.getMessage());
         });
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(value1, null);
+            combiner.combine(value1, null, value2);
         }, e -> {
             Assert.assertEquals("The combine parameter v2 can't be null",
+                                e.getMessage());
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            combiner.combine(value1, value2, null);
+        }, e -> {
+            Assert.assertEquals("The combine parameter result can't be null",
                                 e.getMessage());
         });
     }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeNewPropertiesCombinerTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeNewPropertiesCombinerTest.java
@@ -42,8 +42,9 @@ public class MergeNewPropertiesCombinerTest extends UnitTestBase {
         expect.put("age", BytesId.of("18"));
         expect.put("city", BytesId.of("Beijing"));
 
+        Properties properties = graphFactory().createProperties();
         PropertiesCombiner combiner = new MergeNewPropertiesCombiner();
-        Properties properties = combiner.combine(properties1, properties2);
+        combiner.combine(properties1, properties2, properties);
         Assert.assertEquals(expect, properties);
     }
 
@@ -61,16 +62,23 @@ public class MergeNewPropertiesCombinerTest extends UnitTestBase {
         PropertiesCombiner combiner = new MergeNewPropertiesCombiner();
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(null, properties2);
+            combiner.combine(null, properties2, properties2);
         }, e -> {
             Assert.assertEquals("The combine parameter v1 can't be null",
                                 e.getMessage());
         });
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(properties1, null);
+            combiner.combine(properties1, null, properties2);
         }, e -> {
             Assert.assertEquals("The combine parameter v2 can't be null",
+                                e.getMessage());
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            combiner.combine(properties1, properties2, null);
+        }, e -> {
+            Assert.assertEquals("The combine parameter result can't be null",
                                 e.getMessage());
         });
     }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeOldPropertiesCombinerTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/MergeOldPropertiesCombinerTest.java
@@ -43,8 +43,9 @@ public class MergeOldPropertiesCombinerTest extends UnitTestBase {
         expect.put("age", BytesId.of("18"));
         expect.put("city", BytesId.of("Beijing"));
 
+        Properties properties = graphFactory().createProperties();
         PropertiesCombiner combiner = new MergeOldPropertiesCombiner();
-        Properties properties = combiner.combine(properties1, properties2);
+        combiner.combine(properties1, properties2, properties);
         Assert.assertEquals(expect, properties);
     }
 
@@ -61,16 +62,23 @@ public class MergeOldPropertiesCombinerTest extends UnitTestBase {
         PropertiesCombiner combiner = new MergeOldPropertiesCombiner();
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(null, properties2);
+            combiner.combine(null, properties2, properties2);
         }, e -> {
             Assert.assertEquals("The combine parameter v1 can't be null",
                                 e.getMessage());
         });
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(properties1, null);
+            combiner.combine(properties1, null, properties2);
         }, e -> {
             Assert.assertEquals("The combine parameter v2 can't be null",
+                                e.getMessage());
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            combiner.combine(properties1, properties2, null);
+        }, e -> {
+            Assert.assertEquals("The combine parameter result can't be null",
                                 e.getMessage());
         });
     }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/OverwriteCombinerTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/OverwriteCombinerTest.java
@@ -64,37 +64,4 @@ public class OverwriteCombinerTest extends UnitTestBase {
                                 e.getMessage());
         });
     }
-
-    //@Test
-    //public void testCombineVertex() {
-    //    GraphFactory factory = graphFactory();
-    //    Id longId1 = BytesId.of(1L);
-    //    DoubleValue value1 = new DoubleValue(0.1D);
-    //    Vertex vertex1 = factory.createVertex(longId1, value1);
-    //    vertex1.addEdge(factory.createEdge(BytesId.of(2L)));
-    //    vertex1.addEdge(factory.createEdge(BytesId.of(3L)));
-    //
-    //    Id longId2 = BytesId.of(1L);
-    //    DoubleValue value2 = new DoubleValue(0.2D);
-    //    Vertex vertex2 = factory.createVertex(longId2, value2);
-    //    vertex2.addEdge(factory.createEdge(BytesId.of(1L)));
-    //
-    //    OverwriteCombiner<Vertex> combiner = new OverwriteCombiner<>();
-    //    Vertex vertex = combiner.combine(vertex1, vertex2);
-    //    Assert.assertEquals(vertex2, vertex);
-    //}
-    //
-    //@Test
-    //public void testCombineProperties() {
-    //    Properties properties1 = graphFactory().createProperties();
-    //    properties1.put("name", BytesId.of("marko"));
-    //    properties1.put("city", BytesId.of("Beijing"));
-    //
-    //    Properties properties2 = graphFactory().createProperties();
-    //    properties1.put("name", BytesId.of("josh"));
-    //
-    //    OverwriteCombiner<Properties> combiner = new OverwriteCombiner<>();
-    //    Properties properties = combiner.combine(properties1, properties2);
-    //    Assert.assertEquals(properties2, properties);
-    //}
 }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/OverwriteCombinerTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/OverwriteCombinerTest.java
@@ -21,14 +21,7 @@ package com.baidu.hugegraph.computer.core.combiner;
 
 import org.junit.Test;
 
-import com.baidu.hugegraph.computer.core.graph.GraphFactory;
-import com.baidu.hugegraph.computer.core.graph.id.BytesId;
-import com.baidu.hugegraph.computer.core.graph.id.Id;
-import com.baidu.hugegraph.computer.core.graph.properties.Properties;
-import com.baidu.hugegraph.computer.core.graph.value.DoubleValue;
 import com.baidu.hugegraph.computer.core.graph.value.LongValue;
-import com.baidu.hugegraph.computer.core.graph.value.Value;
-import com.baidu.hugegraph.computer.core.graph.vertex.Vertex;
 import com.baidu.hugegraph.computer.suite.unit.UnitTestBase;
 import com.baidu.hugegraph.testutil.Assert;
 
@@ -39,8 +32,10 @@ public class OverwriteCombinerTest extends UnitTestBase {
         LongValue value1 = new LongValue(1L);
         LongValue value2 = new LongValue(2L);
         OverwriteCombiner<LongValue> combiner = new OverwriteCombiner<>();
-        Value value = combiner.combine(value1, value2);
-        Assert.assertEquals(value2, value);
+        combiner.combine(value1, value2, value2);
+        Assert.assertEquals(value2, value2);
+        combiner.combine(value1, value2, value1);
+        Assert.assertEquals(value2, value1);
     }
 
     @Test
@@ -49,50 +44,57 @@ public class OverwriteCombinerTest extends UnitTestBase {
         LongValue value2 = new LongValue(2L);
         OverwriteCombiner<LongValue> combiner = new OverwriteCombiner<>();
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(null, value2);
+            combiner.combine(null, value2,  value2);
         }, e -> {
             Assert.assertEquals("The combine parameter v1 can't be null",
                                 e.getMessage());
         });
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(value1, null);
+            combiner.combine(value1, null, value2);
         }, e -> {
             Assert.assertEquals("The combine parameter v2 can't be null",
                                 e.getMessage());
         });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            combiner.combine(value1, value2, null);
+        }, e -> {
+            Assert.assertEquals("The combine parameter result can't be null",
+                                e.getMessage());
+        });
     }
 
-    @Test
-    public void testCombineVertex() {
-        GraphFactory factory = graphFactory();
-        Id longId1 = BytesId.of(1L);
-        DoubleValue value1 = new DoubleValue(0.1D);
-        Vertex vertex1 = factory.createVertex(longId1, value1);
-        vertex1.addEdge(factory.createEdge(BytesId.of(2L)));
-        vertex1.addEdge(factory.createEdge(BytesId.of(3L)));
-
-        Id longId2 = BytesId.of(1L);
-        DoubleValue value2 = new DoubleValue(0.2D);
-        Vertex vertex2 = factory.createVertex(longId2, value2);
-        vertex2.addEdge(factory.createEdge(BytesId.of(1L)));
-
-        OverwriteCombiner<Vertex> combiner = new OverwriteCombiner<>();
-        Vertex vertex = combiner.combine(vertex1, vertex2);
-        Assert.assertEquals(vertex2, vertex);
-    }
-
-    @Test
-    public void testCombineProperties() {
-        Properties properties1 = graphFactory().createProperties();
-        properties1.put("name", BytesId.of("marko"));
-        properties1.put("city", BytesId.of("Beijing"));
-
-        Properties properties2 = graphFactory().createProperties();
-        properties1.put("name", BytesId.of("josh"));
-
-        OverwriteCombiner<Properties> combiner = new OverwriteCombiner<>();
-        Properties properties = combiner.combine(properties1, properties2);
-        Assert.assertEquals(properties2, properties);
-    }
+    //@Test
+    //public void testCombineVertex() {
+    //    GraphFactory factory = graphFactory();
+    //    Id longId1 = BytesId.of(1L);
+    //    DoubleValue value1 = new DoubleValue(0.1D);
+    //    Vertex vertex1 = factory.createVertex(longId1, value1);
+    //    vertex1.addEdge(factory.createEdge(BytesId.of(2L)));
+    //    vertex1.addEdge(factory.createEdge(BytesId.of(3L)));
+    //
+    //    Id longId2 = BytesId.of(1L);
+    //    DoubleValue value2 = new DoubleValue(0.2D);
+    //    Vertex vertex2 = factory.createVertex(longId2, value2);
+    //    vertex2.addEdge(factory.createEdge(BytesId.of(1L)));
+    //
+    //    OverwriteCombiner<Vertex> combiner = new OverwriteCombiner<>();
+    //    Vertex vertex = combiner.combine(vertex1, vertex2);
+    //    Assert.assertEquals(vertex2, vertex);
+    //}
+    //
+    //@Test
+    //public void testCombineProperties() {
+    //    Properties properties1 = graphFactory().createProperties();
+    //    properties1.put("name", BytesId.of("marko"));
+    //    properties1.put("city", BytesId.of("Beijing"));
+    //
+    //    Properties properties2 = graphFactory().createProperties();
+    //    properties1.put("name", BytesId.of("josh"));
+    //
+    //    OverwriteCombiner<Properties> combiner = new OverwriteCombiner<>();
+    //    Properties properties = combiner.combine(properties1, properties2);
+    //    Assert.assertEquals(properties2, properties);
+    //}
 }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/PointerCombinerTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/PointerCombinerTest.java
@@ -29,6 +29,7 @@ import com.baidu.hugegraph.computer.core.common.exception.ComputerException;
 import com.baidu.hugegraph.computer.core.config.ComputerOptions;
 import com.baidu.hugegraph.computer.core.config.Config;
 import com.baidu.hugegraph.computer.core.graph.GraphFactory;
+import com.baidu.hugegraph.computer.core.graph.properties.DefaultProperties;
 import com.baidu.hugegraph.computer.core.graph.properties.Properties;
 import com.baidu.hugegraph.computer.core.graph.value.DoubleValue;
 import com.baidu.hugegraph.computer.core.graph.value.LongValue;
@@ -36,6 +37,7 @@ import com.baidu.hugegraph.computer.core.graph.value.Value;
 import com.baidu.hugegraph.computer.core.io.BytesInput;
 import com.baidu.hugegraph.computer.core.io.BytesOutput;
 import com.baidu.hugegraph.computer.core.io.IOFactory;
+import com.baidu.hugegraph.computer.core.sort.SorterTestUtil;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.InlinePointer;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
 import com.baidu.hugegraph.computer.suite.unit.UnitTestBase;
@@ -52,10 +54,8 @@ public class PointerCombinerTest extends UnitTestBase {
         Combiner<DoubleValue> combiner = config.createObject(
                               ComputerOptions.WORKER_COMBINER_CLASS);
 
-        PointerCombiner<DoubleValue> pointerCombiner = new PointerCombiner<>(
-                                                       new DoubleValue(),
-                                                       new DoubleValue(),
-                                                       combiner);
+        PointerCombiner<DoubleValue> pointerCombiner =
+        SorterTestUtil.newValuePointerCombiner(DoubleValue::new, combiner);
 
         try (BytesOutput bytesOutput1 = IOFactory.createBytesOutput(
                                         Constants.SMALL_BUF_SIZE);
@@ -94,10 +94,10 @@ public class PointerCombinerTest extends UnitTestBase {
         ComputerOptions.WORKER_VERTEX_PROPERTIES_COMBINER_CLASS);
 
         GraphFactory graphFactory = graphFactory();
-        PointerCombiner<Properties> pointerCombiner = new PointerCombiner<>(
-                                    graphFactory.createProperties(),
-                                    graphFactory.createProperties(),
-                                    combiner);
+        PointerCombiner<Properties> pointerCombiner =
+                        SorterTestUtil.newValuePointerCombiner(() -> {
+                            return new DefaultProperties(graphFactory);
+                        }, combiner);
 
         try (BytesOutput bytesOutput1 = IOFactory.createBytesOutput(
                                         Constants.SMALL_BUF_SIZE);
@@ -142,15 +142,15 @@ public class PointerCombinerTest extends UnitTestBase {
 
         GraphFactory graphFactory = graphFactory();
 
-        PointerCombiner<Properties> pointerCombiner = new PointerCombiner<>(
-                                    graphFactory.createProperties(),
-                                    graphFactory.createProperties(),
-                                    combiner);
+        PointerCombiner<Properties> pointerCombiner =
+                        SorterTestUtil.newValuePointerCombiner(() -> {
+                            return new DefaultProperties(graphFactory);
+                        }, combiner);
 
         try (BytesOutput bytesOutput1 = IOFactory.createBytesOutput(
                                         Constants.SMALL_BUF_SIZE);
              BytesOutput bytesOutput2 = IOFactory.createBytesOutput(
-                                        Constants.SMALL_BUF_SIZE);) {
+                                        Constants.SMALL_BUF_SIZE)) {
             Properties value1 = graphFactory.createProperties();
             value1.put("p1", new LongValue(1L));
             Properties value2 = graphFactory.createProperties();

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/PointerCombinerTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/PointerCombinerTest.java
@@ -95,9 +95,9 @@ public class PointerCombinerTest extends UnitTestBase {
 
         GraphFactory graphFactory = graphFactory();
         PointerCombiner<Properties> pointerCombiner =
-                        SorterTestUtil.newValuePointerCombiner(() -> {
-                            return new DefaultProperties(graphFactory);
-                        }, combiner);
+                        SorterTestUtil.newValuePointerCombiner(
+                                       graphFactory::createProperties,
+                                       combiner);
 
         try (BytesOutput bytesOutput1 = IOFactory.createBytesOutput(
                                         Constants.SMALL_BUF_SIZE);

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/ValueMaxCombinerTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/ValueMaxCombinerTest.java
@@ -31,9 +31,9 @@ public class ValueMaxCombinerTest {
         LongValue max = new LongValue(0L);
         ValueMaxCombiner<LongValue> combiner = new ValueMaxCombiner<>();
         LongValue value1 = new LongValue(1L);
-        max = combiner.combine(max, value1);
+        combiner.combine(max, value1, max);
         LongValue value2 = new LongValue(2L);
-        max = combiner.combine(value2, max);
+        combiner.combine(value2, max, max);
         Assert.assertEquals(new LongValue(2L), max);
     }
 
@@ -43,16 +43,23 @@ public class ValueMaxCombinerTest {
         LongValue value2 = new LongValue(2L);
         ValueMaxCombiner<LongValue> combiner = new ValueMaxCombiner<>();
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(null, value2);
+            combiner.combine(null, value2, value2);
         }, e -> {
             Assert.assertEquals("The combine parameter v1 can't be null",
                                 e.getMessage());
         });
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(value1, null);
+            combiner.combine(value1, null, value2);
         }, e -> {
             Assert.assertEquals("The combine parameter v2 can't be null",
+                                e.getMessage());
+        });
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> {
+            combiner.combine(value1, value2, null);
+        }, e -> {
+            Assert.assertEquals("The combine parameter result can't be null",
                                 e.getMessage());
         });
     }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/ValueMinCombinerTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/combiner/ValueMinCombinerTest.java
@@ -31,9 +31,9 @@ public class ValueMinCombinerTest {
         LongValue min = new LongValue(0L);
         ValueMinCombiner<LongValue> combiner = new ValueMinCombiner<>();
         LongValue value1 = new LongValue(1L);
-        min = combiner.combine(min, value1);
+        combiner.combine(min, value1, min);
         LongValue value2 = new LongValue(2L);
-        min = combiner.combine(value2, min);
+        combiner.combine(value2, min, min);
         Assert.assertEquals(new LongValue(0L), min);
     }
 
@@ -43,14 +43,14 @@ public class ValueMinCombinerTest {
         LongValue value2 = new LongValue(2L);
         ValueMinCombiner<LongValue> combiner = new ValueMinCombiner<>();
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(null, value2);
+            combiner.combine(null, value2, value2);
         }, e -> {
             Assert.assertEquals("The combine parameter v1 can't be null",
                                 e.getMessage());
         });
 
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            combiner.combine(value1, null);
+            combiner.combine(value1, null, value1);
         }, e -> {
             Assert.assertEquals("The combine parameter v2 can't be null",
                                 e.getMessage());

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/compute/ComputeManagerTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/compute/ComputeManagerTest.java
@@ -19,21 +19,15 @@
 
 package com.baidu.hugegraph.computer.core.compute;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
 import java.util.function.Consumer;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.baidu.hugegraph.computer.core.combiner.EdgeValueCombiner;
-import com.baidu.hugegraph.computer.core.combiner.AbstractPointerCombiner;
 import com.baidu.hugegraph.computer.core.common.Constants;
 import com.baidu.hugegraph.computer.core.config.ComputerOptions;
 import com.baidu.hugegraph.computer.core.config.Config;
@@ -51,8 +45,6 @@ import com.baidu.hugegraph.computer.core.graph.vertex.Vertex;
 import com.baidu.hugegraph.computer.core.io.BytesOutput;
 import com.baidu.hugegraph.computer.core.io.GraphComputeOutput;
 import com.baidu.hugegraph.computer.core.io.IOFactory;
-import com.baidu.hugegraph.computer.core.io.RandomAccessInput;
-import com.baidu.hugegraph.computer.core.io.StreamGraphInput;
 import com.baidu.hugegraph.computer.core.io.StreamGraphOutput;
 import com.baidu.hugegraph.computer.core.manager.Managers;
 import com.baidu.hugegraph.computer.core.network.ConnectionId;
@@ -61,19 +53,11 @@ import com.baidu.hugegraph.computer.core.network.message.MessageType;
 import com.baidu.hugegraph.computer.core.receiver.MessageRecvManager;
 import com.baidu.hugegraph.computer.core.receiver.ReceiverUtil;
 import com.baidu.hugegraph.computer.core.sender.MessageSendManager;
-import com.baidu.hugegraph.computer.core.sort.Sorter;
-import com.baidu.hugegraph.computer.core.sort.flusher.CombineSubKvOuterSortFlusher;
-import com.baidu.hugegraph.computer.core.sort.flusher.OuterSortFlusher;
 import com.baidu.hugegraph.computer.core.sort.sorting.SendSortManager;
 import com.baidu.hugegraph.computer.core.sort.sorting.SortManager;
 import com.baidu.hugegraph.computer.core.store.FileManager;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.buffer.EntryIterator;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.EntryOutput;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.EntryOutputImpl;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.KvEntry;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.file.reader.HgkvDirReader;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.file.reader.HgkvDirReaderImpl;
 import com.baidu.hugegraph.computer.core.worker.Computation;
 import com.baidu.hugegraph.computer.suite.unit.UnitTestBase;
 import com.baidu.hugegraph.testutil.Whitebox;
@@ -249,68 +233,6 @@ public class ComputeManagerTest extends UnitTestBase {
                 ReceiverUtil.consumeBuffer(ReceiverUtil.writeMessage(id,
                                                                      message),
                                            consumer);
-            }
-        }
-    }
-
-    @Test
-    public void test() throws Exception {
-        List<RandomAccessInput> buffers = new ArrayList<>();
-        for (long i = 0L; i < 3; i++) {
-            Vertex vertex = graphFactory().createVertex();
-            vertex.id(BytesId.of(1));
-            Edges edges = graphFactory().createEdges(3);
-
-            for (long j = 0; j < 3; j++) {
-                Edge edge = graphFactory().createEdge();
-                edge.targetId(BytesId.of(j));
-                edge.label("hello");
-                Properties properties = graphFactory().createProperties();
-                properties.put("p1", new LongValue(0));
-                edge.properties(properties);
-                edges.add(edge);
-            }
-            vertex.edges(edges);
-            byte[] bytes = writeEdges(vertex, EdgeFrequency.SINGLE);
-            buffers.add(IOFactory.createBytesInput(bytes));
-        }
-
-        SortManager sorter = this.managers.get("send_sort");
-
-        AbstractPointerCombiner combiner = new EdgeValueCombiner(context());
-        OuterSortFlusher flusher = new CombineSubKvOuterSortFlusher(combiner,
-                                                                    5);
-        String path = "~/test/a";
-        FileUtils.deleteDirectory(new File(path));
-        Sorter sorter1 = Whitebox.getInternalState(sorter, "sorter");
-        flusher.sources(buffers.size());
-        sorter1.mergeBuffers(buffers, flusher, path, true);
-
-        HgkvDirReader reader = new HgkvDirReaderImpl(path, true);
-        EntryIterator iterator = reader.iterator();
-        while (iterator.hasNext()) {
-            KvEntry next = iterator.next();
-            Pointer key = next.key();
-            Pointer value = next.value();
-
-            BytesId bytesId = new BytesId();
-            bytesId.read(key.input());
-
-            RandomAccessInput input = value.input();
-            int count = input.readFixedInt();
-            Edges edges = graphFactory().createEdges(count);
-            for (int i = 0; i < count; i++) {
-                Edge edge = graphFactory().createEdge();
-                // Only use targetId as subKey, use props as subValue
-                input.readFixedInt();
-                edge.targetId(StreamGraphInput.readId(input));
-                // Read subValue
-                input.readFixedInt();
-                Properties props = graphFactory().createProperties();
-                props.read(input);
-                edge.properties(props);
-                edge.label(StreamGraphInput.readLabel(input));
-                edges.add(edge);
             }
         }
     }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/compute/ComputeManagerTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/compute/ComputeManagerTest.java
@@ -19,15 +19,21 @@
 
 package com.baidu.hugegraph.computer.core.compute;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import java.util.function.Consumer;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.baidu.hugegraph.computer.core.combiner.EdgeValueCombiner;
+import com.baidu.hugegraph.computer.core.combiner.AbstractPointerCombiner;
 import com.baidu.hugegraph.computer.core.common.Constants;
 import com.baidu.hugegraph.computer.core.config.ComputerOptions;
 import com.baidu.hugegraph.computer.core.config.Config;
@@ -45,6 +51,8 @@ import com.baidu.hugegraph.computer.core.graph.vertex.Vertex;
 import com.baidu.hugegraph.computer.core.io.BytesOutput;
 import com.baidu.hugegraph.computer.core.io.GraphComputeOutput;
 import com.baidu.hugegraph.computer.core.io.IOFactory;
+import com.baidu.hugegraph.computer.core.io.RandomAccessInput;
+import com.baidu.hugegraph.computer.core.io.StreamGraphInput;
 import com.baidu.hugegraph.computer.core.io.StreamGraphOutput;
 import com.baidu.hugegraph.computer.core.manager.Managers;
 import com.baidu.hugegraph.computer.core.network.ConnectionId;
@@ -53,11 +61,19 @@ import com.baidu.hugegraph.computer.core.network.message.MessageType;
 import com.baidu.hugegraph.computer.core.receiver.MessageRecvManager;
 import com.baidu.hugegraph.computer.core.receiver.ReceiverUtil;
 import com.baidu.hugegraph.computer.core.sender.MessageSendManager;
+import com.baidu.hugegraph.computer.core.sort.Sorter;
+import com.baidu.hugegraph.computer.core.sort.flusher.CombineSubKvOuterSortFlusher;
+import com.baidu.hugegraph.computer.core.sort.flusher.OuterSortFlusher;
 import com.baidu.hugegraph.computer.core.sort.sorting.SendSortManager;
 import com.baidu.hugegraph.computer.core.sort.sorting.SortManager;
 import com.baidu.hugegraph.computer.core.store.FileManager;
+import com.baidu.hugegraph.computer.core.store.hgkvfile.buffer.EntryIterator;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.EntryOutput;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.EntryOutputImpl;
+import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.KvEntry;
+import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
+import com.baidu.hugegraph.computer.core.store.hgkvfile.file.reader.HgkvDirReader;
+import com.baidu.hugegraph.computer.core.store.hgkvfile.file.reader.HgkvDirReaderImpl;
 import com.baidu.hugegraph.computer.core.worker.Computation;
 import com.baidu.hugegraph.computer.suite.unit.UnitTestBase;
 import com.baidu.hugegraph.testutil.Whitebox;
@@ -233,6 +249,68 @@ public class ComputeManagerTest extends UnitTestBase {
                 ReceiverUtil.consumeBuffer(ReceiverUtil.writeMessage(id,
                                                                      message),
                                            consumer);
+            }
+        }
+    }
+
+    @Test
+    public void test() throws Exception {
+        List<RandomAccessInput> buffers = new ArrayList<>();
+        for (long i = 0L; i < 3; i++) {
+            Vertex vertex = graphFactory().createVertex();
+            vertex.id(BytesId.of(1));
+            Edges edges = graphFactory().createEdges(3);
+
+            for (long j = 0; j < 3; j++) {
+                Edge edge = graphFactory().createEdge();
+                edge.targetId(BytesId.of(j));
+                edge.label("hello");
+                Properties properties = graphFactory().createProperties();
+                properties.put("p1", new LongValue(0));
+                edge.properties(properties);
+                edges.add(edge);
+            }
+            vertex.edges(edges);
+            byte[] bytes = writeEdges(vertex, EdgeFrequency.SINGLE);
+            buffers.add(IOFactory.createBytesInput(bytes));
+        }
+
+        SortManager sorter = this.managers.get("send_sort");
+
+        AbstractPointerCombiner combiner = new EdgeValueCombiner(context());
+        OuterSortFlusher flusher = new CombineSubKvOuterSortFlusher(combiner,
+                                                                    5);
+        String path = "~/test/a";
+        FileUtils.deleteDirectory(new File(path));
+        Sorter sorter1 = Whitebox.getInternalState(sorter, "sorter");
+        flusher.sources(buffers.size());
+        sorter1.mergeBuffers(buffers, flusher, path, true);
+
+        HgkvDirReader reader = new HgkvDirReaderImpl(path, true);
+        EntryIterator iterator = reader.iterator();
+        while (iterator.hasNext()) {
+            KvEntry next = iterator.next();
+            Pointer key = next.key();
+            Pointer value = next.value();
+
+            BytesId bytesId = new BytesId();
+            bytesId.read(key.input());
+
+            RandomAccessInput input = value.input();
+            int count = input.readFixedInt();
+            Edges edges = graphFactory().createEdges(count);
+            for (int i = 0; i < count; i++) {
+                Edge edge = graphFactory().createEdge();
+                // Only use targetId as subKey, use props as subValue
+                input.readFixedInt();
+                edge.targetId(StreamGraphInput.readId(input));
+                // Read subValue
+                input.readFixedInt();
+                Properties props = graphFactory().createProperties();
+                props.read(input);
+                edge.properties(props);
+                edge.label(StreamGraphInput.readLabel(input));
+                edges.add(edge);
             }
         }
     }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/SorterTestUtil.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/SorterTestUtil.java
@@ -24,12 +24,20 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
+import com.baidu.hugegraph.computer.core.combiner.Combiner;
+import com.baidu.hugegraph.computer.core.combiner.IntValueSumCombiner;
+import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.common.Constants;
+import com.baidu.hugegraph.computer.core.common.exception.ComputerException;
 import com.baidu.hugegraph.computer.core.graph.id.Id;
+import com.baidu.hugegraph.computer.core.graph.value.IntValue;
 import com.baidu.hugegraph.computer.core.io.BytesInput;
 import com.baidu.hugegraph.computer.core.io.BytesOutput;
 import com.baidu.hugegraph.computer.core.io.IOFactory;
+import com.baidu.hugegraph.computer.core.io.Readable;
+import com.baidu.hugegraph.computer.core.io.Writable;
 import com.baidu.hugegraph.computer.core.store.StoreTestUtil;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.EntriesUtil;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.KvEntry;
@@ -151,6 +159,24 @@ public class SorterTestUtil {
                                 StoreTestUtil.dataFromPointer(subKv.key()));
             Assert.assertEquals(expect[index++],
                                 StoreTestUtil.dataFromPointer(subKv.value()));
+        }
+    }
+
+    public static PointerCombiner<IntValue> newIntValueSumPointerCombiner() {
+        return newValuePointerCombiner(IntValue::new,
+                                       new IntValueSumCombiner());
+    }
+
+    public static <T extends Readable & Writable> PointerCombiner<T>
+           newValuePointerCombiner(Supplier<T> supplier, Combiner<T> combiner) {
+        try {
+            T v1 = supplier.get();
+            T v2 = supplier.get();
+            T v3 = supplier.get();
+            return new PointerCombiner<>(v1, v2, v3, combiner);
+        } catch (Exception e) {
+           throw new ComputerException("Failed to create PointerCombiner for " +
+                                       "class:");
         }
     }
 }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/SorterTestUtil.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/SorterTestUtil.java
@@ -26,13 +26,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import com.baidu.hugegraph.computer.core.combiner.AbstractPointerCombiner;
 import com.baidu.hugegraph.computer.core.combiner.Combiner;
-import com.baidu.hugegraph.computer.core.combiner.IntValueSumCombiner;
 import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.common.Constants;
-import com.baidu.hugegraph.computer.core.common.exception.ComputerException;
 import com.baidu.hugegraph.computer.core.graph.id.Id;
-import com.baidu.hugegraph.computer.core.graph.value.IntValue;
 import com.baidu.hugegraph.computer.core.io.BytesInput;
 import com.baidu.hugegraph.computer.core.io.BytesOutput;
 import com.baidu.hugegraph.computer.core.io.IOFactory;
@@ -162,21 +160,9 @@ public class SorterTestUtil {
         }
     }
 
-    public static PointerCombiner<IntValue> newIntValueSumPointerCombiner() {
-        return newValuePointerCombiner(IntValue::new,
-                                       new IntValueSumCombiner());
-    }
-
-    public static <T extends Readable & Writable> PointerCombiner<T>
-           newValuePointerCombiner(Supplier<T> supplier, Combiner<T> combiner) {
-        try {
-            T v1 = supplier.get();
-            T v2 = supplier.get();
-            T v3 = supplier.get();
-            return new PointerCombiner<>(v1, v2, v3, combiner);
-        } catch (Exception e) {
-           throw new ComputerException("Failed to create PointerCombiner for " +
-                                       "class:");
-        }
+    public static <T extends Readable & Writable> PointerCombiner
+                  createPointerCombiner(Supplier<T> supplier,
+                                        Combiner<T> combiner) {
+        return new AbstractPointerCombiner<T>(supplier, combiner) { };
     }
 }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/combiner/MockIntSumCombiner.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/combiner/MockIntSumCombiner.java
@@ -19,25 +19,13 @@
 
 package com.baidu.hugegraph.computer.core.sort.combiner;
 
-import java.io.IOException;
-
 import com.baidu.hugegraph.computer.core.combiner.Combiner;
-import com.baidu.hugegraph.computer.core.common.exception.ComputerException;
-import com.baidu.hugegraph.computer.core.store.StoreTestUtil;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.InlinePointer;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
+import com.baidu.hugegraph.computer.core.graph.value.IntValue;
 
-public class MockIntSumCombiner implements Combiner<Pointer> {
+public class MockIntSumCombiner implements Combiner<IntValue> {
 
     @Override
-    public Pointer combine(Pointer v1, Pointer v2) {
-        try {
-            Integer d1 = StoreTestUtil.dataFromPointer(v1);
-            Integer d2 = StoreTestUtil.dataFromPointer(v2);
-
-            return new InlinePointer(StoreTestUtil.intToByteArray(d1 + d2));
-        } catch (IOException e) {
-            throw new ComputerException(e.getMessage(), e);
-        }
+    public void combine(IntValue v1, IntValue v2, IntValue result) {
+        result.value(v1.intValue() + v2.intValue());
     }
 }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/sorter/FlusherTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/sorter/FlusherTest.java
@@ -25,11 +25,11 @@ import java.util.List;
 
 import org.junit.Test;
 
-import com.baidu.hugegraph.computer.core.combiner.Combiner;
-import com.baidu.hugegraph.computer.core.combiner.OverwriteCombiner;
+import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.common.ComputerContext;
 import com.baidu.hugegraph.computer.core.common.Constants;
 import com.baidu.hugegraph.computer.core.config.Config;
+import com.baidu.hugegraph.computer.core.graph.value.IntValue;
 import com.baidu.hugegraph.computer.core.io.BytesInput;
 import com.baidu.hugegraph.computer.core.io.BytesOutput;
 import com.baidu.hugegraph.computer.core.io.IOFactory;
@@ -46,7 +46,6 @@ import com.baidu.hugegraph.computer.core.store.hgkvfile.buffer.EntryIterator;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.buffer.KvEntriesInput;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.EntriesUtil;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.KvEntry;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
 import com.baidu.hugegraph.testutil.Assert;
 import com.google.common.collect.ImmutableList;
 
@@ -131,7 +130,8 @@ public class FlusherTest {
 
         BytesOutput output = IOFactory.createBytesOutput(
                              Constants.SMALL_BUF_SIZE);
-        Combiner<Pointer> combiner = new OverwriteCombiner<>();
+        PointerCombiner<IntValue> combiner =
+                        SorterTestUtil.newIntValueSumPointerCombiner();
         InnerSortFlusher flusher = new CombineKvInnerSortFlusher(output,
                                                                  combiner);
         Sorter sorter = new SorterImpl(CONFIG);

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/sorter/FlusherTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/sorter/FlusherTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import com.baidu.hugegraph.computer.core.combiner.OverwriteCombiner;
 import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.common.ComputerContext;
 import com.baidu.hugegraph.computer.core.common.Constants;
@@ -130,8 +131,9 @@ public class FlusherTest {
 
         BytesOutput output = IOFactory.createBytesOutput(
                              Constants.SMALL_BUF_SIZE);
-        PointerCombiner<IntValue> combiner =
-                        SorterTestUtil.newIntValueSumPointerCombiner();
+        PointerCombiner combiner = SorterTestUtil.createPointerCombiner(
+                                                  IntValue::new,
+                                                  new OverwriteCombiner<>());
         InnerSortFlusher flusher = new CombineKvInnerSortFlusher(output,
                                                                  combiner);
         Sorter sorter = new SorterImpl(CONFIG);

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/sorter/SortLargeDataTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/sorter/SortLargeDataTest.java
@@ -313,8 +313,8 @@ public class SortLargeDataTest {
     private static void assertFileOrder(Sorter sorter, List<String> files)
                                         throws Exception {
         KvEntry last = null;
-        try (PeekableIterator<KvEntry> iterator = sorter
-                .iterator(files, false)) {
+        try (PeekableIterator<KvEntry> iterator =
+                                       sorter.iterator(files, false)) {
             while (iterator.hasNext()) {
                 KvEntry next = iterator.next();
                 if (last == null) {

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/sorter/SortLargeDataTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/sorter/SortLargeDataTest.java
@@ -33,6 +33,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 
+import com.baidu.hugegraph.computer.core.combiner.IntValueSumCombiner;
 import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.common.Constants;
 import com.baidu.hugegraph.computer.core.config.ComputerOptions;
@@ -265,8 +266,9 @@ public class SortLargeDataTest {
                                                 throws Exception {
         BytesOutput output = IOFactory.createBytesOutput(
                              Constants.SMALL_BUF_SIZE);
-        PointerCombiner<IntValue> combiner =
-                        SorterTestUtil.newIntValueSumPointerCombiner();
+        PointerCombiner combiner = SorterTestUtil.createPointerCombiner(
+                                                  IntValue::new,
+                                                  new IntValueSumCombiner());
         InnerSortFlusher flusher = new CombineKvInnerSortFlusher(output,
                                                                  combiner);
         sorter.sortBuffer(input, flusher, false);
@@ -276,16 +278,18 @@ public class SortLargeDataTest {
     private static void mergeBuffers(Sorter sorter,
                                      List<RandomAccessInput> buffers,
                                      String output) throws Exception {
-        PointerCombiner<IntValue> combiner =
-                        SorterTestUtil.newIntValueSumPointerCombiner();
+        PointerCombiner combiner = SorterTestUtil.createPointerCombiner(
+                                                  IntValue::new,
+                                                  new IntValueSumCombiner());
         OuterSortFlusher flusher = new CombineKvOuterSortFlusher(combiner);
         sorter.mergeBuffers(buffers, flusher, output, false);
     }
 
     private static void mergeFiles(Sorter sorter, List<String> files,
                                    List<String> outputs) throws Exception {
-        PointerCombiner<IntValue> combiner =
-                        SorterTestUtil.newIntValueSumPointerCombiner();
+        PointerCombiner combiner = SorterTestUtil.createPointerCombiner(
+                                                  IntValue::new,
+                                                  new IntValueSumCombiner());
         OuterSortFlusher flusher = new CombineKvOuterSortFlusher(combiner);
         sorter.mergeInputs(files, flusher, outputs, false);
     }

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/sorter/SorterTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/sorter/SorterTest.java
@@ -30,10 +30,11 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.baidu.hugegraph.computer.core.combiner.Combiner;
+import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.common.Constants;
 import com.baidu.hugegraph.computer.core.config.ComputerOptions;
 import com.baidu.hugegraph.computer.core.config.Config;
+import com.baidu.hugegraph.computer.core.graph.value.IntValue;
 import com.baidu.hugegraph.computer.core.io.BytesInput;
 import com.baidu.hugegraph.computer.core.io.BytesOutput;
 import com.baidu.hugegraph.computer.core.io.IOFactory;
@@ -41,7 +42,6 @@ import com.baidu.hugegraph.computer.core.io.RandomAccessInput;
 import com.baidu.hugegraph.computer.core.sort.Sorter;
 import com.baidu.hugegraph.computer.core.sort.SorterImpl;
 import com.baidu.hugegraph.computer.core.sort.SorterTestUtil;
-import com.baidu.hugegraph.computer.core.sort.combiner.MockIntSumCombiner;
 import com.baidu.hugegraph.computer.core.sort.flusher.CombineKvInnerSortFlusher;
 import com.baidu.hugegraph.computer.core.sort.flusher.CombineKvOuterSortFlusher;
 import com.baidu.hugegraph.computer.core.sort.flusher.CombineSubKvInnerSortFlusher;
@@ -53,7 +53,6 @@ import com.baidu.hugegraph.computer.core.store.hgkvfile.buffer.EntryIterator;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.buffer.KvEntriesInput;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.EntriesUtil;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.KvEntry;
-import com.baidu.hugegraph.computer.core.store.hgkvfile.entry.Pointer;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.file.HgkvDir;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.file.HgkvDirImpl;
 import com.baidu.hugegraph.computer.core.store.hgkvfile.file.reader.HgkvDirReader;
@@ -103,7 +102,8 @@ public class SorterTest {
                              Constants.SMALL_BUF_SIZE);
 
         SorterImpl sorter = new SorterImpl(CONFIG);
-        Combiner<Pointer> combiner = new MockIntSumCombiner();
+        PointerCombiner<IntValue> combiner =
+                        SorterTestUtil.newIntValueSumPointerCombiner();
         sorter.sortBuffer(input,
                           new CombineKvInnerSortFlusher(output, combiner),
                           false);
@@ -138,7 +138,8 @@ public class SorterTest {
                                 SorterTestUtil.inputFromKvMap(map1),
                                 SorterTestUtil.inputFromKvMap(map2));
         SorterImpl sorter = new SorterImpl(CONFIG);
-        Combiner<Pointer> combiner = new MockIntSumCombiner();
+        PointerCombiner<IntValue> combiner =
+                        SorterTestUtil.newIntValueSumPointerCombiner();
         sorter.mergeBuffers(inputs, new CombineKvOuterSortFlusher(combiner),
                             path, false);
 
@@ -199,7 +200,8 @@ public class SorterTest {
 
         // Merge file
         Sorter sorter = new SorterImpl(CONFIG);
-        Combiner<Pointer> combiner = new MockIntSumCombiner();
+        PointerCombiner<IntValue> combiner =
+                        SorterTestUtil.newIntValueSumPointerCombiner();
         sorter.mergeInputs(inputs, new CombineKvOuterSortFlusher(combiner),
                            outputs, false);
 
@@ -258,7 +260,8 @@ public class SorterTest {
         BytesInput input = SorterTestUtil.inputFromSubKvMap(data);
         BytesOutput output = IOFactory.createBytesOutput(
                              Constants.SMALL_BUF_SIZE);
-        Combiner<Pointer> combiner = new MockIntSumCombiner();
+        PointerCombiner<IntValue> combiner =
+                        SorterTestUtil.newIntValueSumPointerCombiner();
         int flushThreshold = config.get(
                              ComputerOptions.INPUT_MAX_EDGES_IN_ONE_VERTEX);
         InnerSortFlusher flusher = new CombineSubKvInnerSortFlusher(
@@ -308,7 +311,8 @@ public class SorterTest {
         List<RandomAccessInput> buffers = ImmutableList.of(i1, i2, i3);
 
         Sorter sorter = new SorterImpl(config);
-        Combiner<Pointer> combiner = new MockIntSumCombiner();
+        PointerCombiner<IntValue> combiner =
+                        SorterTestUtil.newIntValueSumPointerCombiner();
         OuterSortFlusher flusher = new CombineSubKvOuterSortFlusher(
                                    combiner, flushThreshold);
         flusher.sources(buffers.size());
@@ -383,7 +387,8 @@ public class SorterTest {
         StoreTestUtil.hgkvDirFromSubKvMap(config, data3, input3);
 
         Sorter sorter = new SorterImpl(config);
-        Combiner<Pointer> combiner = new MockIntSumCombiner();
+        PointerCombiner<IntValue> combiner =
+                        SorterTestUtil.newIntValueSumPointerCombiner();
         OuterSortFlusher flusher = new CombineSubKvOuterSortFlusher(
                                        combiner, flushThreshold);
         flusher.sources(inputs.size());

--- a/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/sorter/SorterTest.java
+++ b/computer-test/src/main/java/com/baidu/hugegraph/computer/core/sort/sorter/SorterTest.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.baidu.hugegraph.computer.core.combiner.IntValueSumCombiner;
 import com.baidu.hugegraph.computer.core.combiner.PointerCombiner;
 import com.baidu.hugegraph.computer.core.common.Constants;
 import com.baidu.hugegraph.computer.core.config.ComputerOptions;
@@ -102,8 +103,9 @@ public class SorterTest {
                              Constants.SMALL_BUF_SIZE);
 
         SorterImpl sorter = new SorterImpl(CONFIG);
-        PointerCombiner<IntValue> combiner =
-                        SorterTestUtil.newIntValueSumPointerCombiner();
+        PointerCombiner combiner = SorterTestUtil.createPointerCombiner(
+                                                  IntValue::new,
+                                                  new IntValueSumCombiner());
         sorter.sortBuffer(input,
                           new CombineKvInnerSortFlusher(output, combiner),
                           false);
@@ -138,8 +140,9 @@ public class SorterTest {
                                 SorterTestUtil.inputFromKvMap(map1),
                                 SorterTestUtil.inputFromKvMap(map2));
         SorterImpl sorter = new SorterImpl(CONFIG);
-        PointerCombiner<IntValue> combiner =
-                        SorterTestUtil.newIntValueSumPointerCombiner();
+        PointerCombiner combiner = SorterTestUtil.createPointerCombiner(
+                                                  IntValue::new,
+                                                  new IntValueSumCombiner());
         sorter.mergeBuffers(inputs, new CombineKvOuterSortFlusher(combiner),
                             path, false);
 
@@ -200,8 +203,9 @@ public class SorterTest {
 
         // Merge file
         Sorter sorter = new SorterImpl(CONFIG);
-        PointerCombiner<IntValue> combiner =
-                        SorterTestUtil.newIntValueSumPointerCombiner();
+        PointerCombiner combiner = SorterTestUtil.createPointerCombiner(
+                                                  IntValue::new,
+                                                  new IntValueSumCombiner());
         sorter.mergeInputs(inputs, new CombineKvOuterSortFlusher(combiner),
                            outputs, false);
 
@@ -260,8 +264,9 @@ public class SorterTest {
         BytesInput input = SorterTestUtil.inputFromSubKvMap(data);
         BytesOutput output = IOFactory.createBytesOutput(
                              Constants.SMALL_BUF_SIZE);
-        PointerCombiner<IntValue> combiner =
-                        SorterTestUtil.newIntValueSumPointerCombiner();
+        PointerCombiner combiner = SorterTestUtil.createPointerCombiner(
+                                                  IntValue::new,
+                                                  new IntValueSumCombiner());
         int flushThreshold = config.get(
                              ComputerOptions.INPUT_MAX_EDGES_IN_ONE_VERTEX);
         InnerSortFlusher flusher = new CombineSubKvInnerSortFlusher(
@@ -311,14 +316,14 @@ public class SorterTest {
         List<RandomAccessInput> buffers = ImmutableList.of(i1, i2, i3);
 
         Sorter sorter = new SorterImpl(config);
-        PointerCombiner<IntValue> combiner =
-                        SorterTestUtil.newIntValueSumPointerCombiner();
+        PointerCombiner combiner = SorterTestUtil.createPointerCombiner(
+                                                  IntValue::new,
+                                                  new IntValueSumCombiner());
         OuterSortFlusher flusher = new CombineSubKvOuterSortFlusher(
-                                   combiner, flushThreshold);
+                                       combiner, flushThreshold);
         flusher.sources(buffers.size());
 
         String outputFile = StoreTestUtil.availablePathById("1");
-        // 这里输出的时候就是subEntries = 5了
         sorter.mergeBuffers(buffers, flusher, outputFile, true);
 
         /*
@@ -387,8 +392,9 @@ public class SorterTest {
         StoreTestUtil.hgkvDirFromSubKvMap(config, data3, input3);
 
         Sorter sorter = new SorterImpl(config);
-        PointerCombiner<IntValue> combiner =
-                        SorterTestUtil.newIntValueSumPointerCombiner();
+        PointerCombiner combiner = SorterTestUtil.createPointerCombiner(
+                                                  IntValue::new,
+                                                  new IntValueSumCombiner());
         OuterSortFlusher flusher = new CombineSubKvOuterSortFlusher(
                                        combiner, flushThreshold);
         flusher.sources(inputs.size());


### PR DESCRIPTION
- PointerCombiner no longer implement Combiner interface.
- The modify scheme for subclasses that implement PropertiesCombiner may not be the best.