### PR TITLE
chore：rename binary package name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Download HDFS
         if: steps.hdfs-cache.outputs.cache-hit != 'true'
-        run: wget http://archive.apache.org/dist/hadoop/common/hadoop-3.3.2/hadoop-3.3.2.tar.gz -O ~/hadoop-3.3.2.tar.gz
+        run: wget https://archive.apache.org/dist/hadoop/common/hadoop-3.3.2/hadoop-3.3.2.tar.gz -O ~/hadoop-3.3.2.tar.gz
 
       - name: Setup HDFS
         run: $TRAVIS_DIR/install-hdfs.sh
@@ -56,18 +56,20 @@ jobs:
           sleep 5
           curl localhost:9000
           kubectl get nodes
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+
+#      - name: Cache Maven packages
+#        uses: actions/cache@v3
+#        with:
+#          path: ~/.m2
+#          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+#          restore-keys: ${{ runner.os }}-m2
 
       - name: Prepare env and service
         run: |
           $TRAVIS_DIR/install-env.sh
           $TRAVIS_DIR/install-hugegraph-from-source.sh $HUGEGRAPH_SERVER_COMMIT_ID | grep -v "Downloading\|Downloaded"
           $TRAVIS_DIR/load-data-into-hugegraph.sh
+
       - name: Install JDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       TRAVIS_DIR: computer-dist/src/assembly/travis
       KUBERNETES_VERSION: 1.20.1
-      HUGEGRAPH_SERVER_COMMIT_ID: b1b12098feb726e46c781a2f171c77558db05fc1
+      HUGEGRAPH_SERVER_COMMIT_ID: d01c8737d7d5909119671953521f1401dcd1a188
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,12 @@ jobs:
           curl localhost:9000
           kubectl get nodes
 
-#      - name: Cache Maven packages
-#        uses: actions/cache@v3
-#        with:
-#          path: ~/.m2
-#          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-#          restore-keys: ${{ runner.os }}-m2
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
 
       - name: Prepare env and service
         run: |

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/betweenness/BetweennessCentrality.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/betweenness/BetweennessCentrality.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/betweenness/BetweennessCentralityParams.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/betweenness/BetweennessCentralityParams.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/betweenness/BetweennessMessage.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/betweenness/BetweennessMessage.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/betweenness/BetweennessValue.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/betweenness/BetweennessValue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/closeness/ClosenessCentrality.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/closeness/ClosenessCentrality.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/closeness/ClosenessCentralityParams.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/closeness/ClosenessCentralityParams.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/closeness/ClosenessMessage.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/closeness/ClosenessMessage.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/closeness/ClosenessValue.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/closeness/ClosenessValue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/degree/DegreeCentrality.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/degree/DegreeCentrality.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/degree/DegreeCentralityParams.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/degree/DegreeCentralityParams.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/pagerank/PageRank.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/pagerank/PageRank.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/pagerank/PageRank4Master.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/pagerank/PageRank4Master.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/pagerank/PageRankParams.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/pagerank/PageRankParams.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/cc/ClusteringCoefficient.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/cc/ClusteringCoefficient.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/cc/ClusteringCoefficientOutput.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/cc/ClusteringCoefficientOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/cc/ClusteringCoefficientParams.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/cc/ClusteringCoefficientParams.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/cc/ClusteringCoefficientValue.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/cc/ClusteringCoefficientValue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/kcore/Kcore.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/kcore/Kcore.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/kcore/KcoreParams.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/kcore/KcoreParams.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/kcore/KcoreValue.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/kcore/KcoreValue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/lpa/Lpa.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/lpa/Lpa.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/lpa/LpaParams.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/lpa/LpaParams.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/trianglecount/TriangleCount.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/trianglecount/TriangleCount.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/trianglecount/TriangleCountParams.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/trianglecount/TriangleCountParams.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/trianglecount/TriangleCountValue.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/trianglecount/TriangleCountValue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/wcc/Wcc.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/wcc/Wcc.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/wcc/WccParams.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/wcc/WccParams.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/RingsDetection.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/RingsDetection.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/RingsDetectionOutput.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/RingsDetectionOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/RingsDetectionParams.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/RingsDetectionParams.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/filter/FilterDescribe.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/filter/FilterDescribe.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/filter/RingsDetectionMessage.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/filter/RingsDetectionMessage.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/filter/RingsDetectionWithFilter.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/filter/RingsDetectionWithFilter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/filter/RingsDetectionWithFilterParams.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/filter/RingsDetectionWithFilterParams.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/filter/SpreadFilter.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/filter/SpreadFilter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/algorithm/AlgorithmParams.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/algorithm/AlgorithmParams.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/aggregator/Aggregator.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/aggregator/Aggregator.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/aggregator/Aggregator4Master.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/aggregator/Aggregator4Master.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/aggregator/Aggregator4Worker.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/aggregator/Aggregator4Worker.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/allocator/Allocator.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/allocator/Allocator.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/allocator/Recyclable.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/allocator/Recyclable.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/allocator/RecyclerReference.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/allocator/RecyclerReference.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/Combiner.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/Combiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/DoubleValueSumCombiner.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/DoubleValueSumCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/FloatValueSumCombiner.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/FloatValueSumCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/IntValueSumCombiner.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/IntValueSumCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/LongValueSumCombiner.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/LongValueSumCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/MergeNewPropertiesCombiner.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/MergeNewPropertiesCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/MergeOldPropertiesCombiner.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/MergeOldPropertiesCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/OverwriteCombiner.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/OverwriteCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/OverwritePropertiesCombiner.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/OverwritePropertiesCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/PropertiesCombiner.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/PropertiesCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/ValueMaxCombiner.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/ValueMaxCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/ValueMinCombiner.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/combiner/ValueMinCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/common/ComputerContext.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/common/ComputerContext.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/common/Constants.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/common/Constants.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/common/SerialEnum.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/common/SerialEnum.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/common/exception/ComputerException.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/common/exception/ComputerException.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/config/ComputerOptions.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/config/ComputerOptions.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/config/Config.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/config/Config.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/config/DefaultConfig.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/config/DefaultConfig.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/config/EdgeFrequency.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/config/EdgeFrequency.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/config/HotConfig.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/config/HotConfig.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/config/Null.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/config/Null.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/GraphFactory.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/GraphFactory.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/edge/Edge.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/edge/Edge.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/edge/Edges.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/edge/Edges.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/id/Id.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/id/Id.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/id/IdFactory.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/id/IdFactory.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/id/IdType.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/id/IdType.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/properties/DefaultProperties.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/properties/DefaultProperties.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/properties/Properties.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/properties/Properties.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/BooleanValue.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/BooleanValue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/DoubleValue.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/DoubleValue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/FloatValue.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/FloatValue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/IdList.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/IdList.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/IdListList.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/IdListList.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/IdSet.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/IdSet.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/IntValue.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/IntValue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/ListValue.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/ListValue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/LongValue.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/LongValue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/MapValue.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/MapValue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/NullValue.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/NullValue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/StringValue.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/StringValue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/Value.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/Value.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/ValueType.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/ValueType.java
@@ -1,6 +1,5 @@
 /*
  *
- *  Copyright 2017 HugeGraph Authors
  *
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/vertex/Vertex.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/vertex/Vertex.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/input/InputFilter.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/input/InputFilter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/BytesInput.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/BytesInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/BytesOutput.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/BytesOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/GraphComputeInput.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/GraphComputeInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/GraphComputeOutput.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/GraphComputeOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/GraphInput.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/GraphInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/GraphOutput.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/GraphOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/GraphWritebackOutput.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/GraphWritebackOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/RandomAccessInput.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/RandomAccessInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/RandomAccessOutput.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/RandomAccessOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/Readable.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/Readable.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/Writable.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/io/Writable.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/master/DefaultMasterComputation.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/master/DefaultMasterComputation.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/master/MasterComputation.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/master/MasterComputation.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/master/MasterComputationContext.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/master/MasterComputationContext.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/master/MasterContext.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/master/MasterContext.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/AbstractComputerOutput.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/AbstractComputerOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/ComputerOutput.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/ComputerOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/HugeGraphOutput.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/HugeGraphOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/exceptions/WriteBackException.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/exceptions/WriteBackException.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/metrics/LoadMetrics.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/metrics/LoadMetrics.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/metrics/LoadReport.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/metrics/LoadReport.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/metrics/LoadSummary.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/metrics/LoadSummary.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/metrics/Printer.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/metrics/Printer.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/task/BatchInsertTask.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/task/BatchInsertTask.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/task/InsertTask.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/task/InsertTask.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/task/SingleInsertTask.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/task/SingleInsertTask.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this
@@ -22,12 +21,12 @@ package org.apache.hugegraph.computer.core.output.hg.task;
 import java.util.List;
 
 import org.apache.hugegraph.computer.core.config.Config;
+import org.apache.hugegraph.computer.core.output.hg.metrics.LoadSummary;
 import org.apache.hugegraph.driver.HugeClient;
 import org.apache.hugegraph.structure.graph.Vertex;
 import org.apache.hugegraph.util.Log;
 import org.slf4j.Logger;
 
-import org.apache.hugegraph.computer.core.output.hg.metrics.LoadSummary;
 import com.google.common.collect.ImmutableList;
 
 public class SingleInsertTask extends InsertTask {

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/task/TaskManager.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/task/TaskManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/util/BytesUtil.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/util/BytesUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/util/CoderUtil.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/util/CoderUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/worker/Computation.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/worker/Computation.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/worker/ComputationContext.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/worker/ComputationContext.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/worker/FilterComputation.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/worker/FilterComputation.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/worker/ReduceComputation.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/worker/ReduceComputation.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/worker/WorkerContext.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/worker/WorkerContext.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/aggregator/Aggregators.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/aggregator/Aggregators.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/aggregator/DefaultAggregator.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/aggregator/DefaultAggregator.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/aggregator/MasterAggrManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/aggregator/MasterAggrManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/aggregator/RegisterAggregators.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/aggregator/RegisterAggregators.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/aggregator/WorkerAggrManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/aggregator/WorkerAggrManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/allocator/DefaultAllocator.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/allocator/DefaultAllocator.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/allocator/RecycleHandler.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/allocator/RecycleHandler.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/bsp/Bsp4Master.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/bsp/Bsp4Master.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/bsp/Bsp4Worker.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/bsp/Bsp4Worker.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/bsp/BspBase.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/bsp/BspBase.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/bsp/BspClient.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/bsp/BspClient.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/bsp/BspEvent.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/bsp/BspEvent.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/bsp/EtcdBspClient.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/bsp/EtcdBspClient.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/bsp/EtcdClient.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/bsp/EtcdClient.java
@@ -1,5 +1,4 @@
 /*
- *  Copyright 2017 HugeGraph Authors
  *
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/combiner/AbstractPointerCombiner.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/combiner/AbstractPointerCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/combiner/EdgeValueCombiner.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/combiner/EdgeValueCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/combiner/MessageValueCombiner.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/combiner/MessageValueCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/combiner/PointerCombiner.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/combiner/PointerCombiner.java
@@ -1,6 +1,5 @@
 package org.apache.hugegraph.computer.core.combiner;
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/combiner/VertexValueCombiner.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/combiner/VertexValueCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/common/ContainerInfo.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/common/ContainerInfo.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/common/exception/IllegalArgException.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/common/exception/IllegalArgException.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/common/exception/ReadException.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/common/exception/ReadException.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/common/exception/TransportException.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/common/exception/TransportException.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/common/exception/WriteException.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/common/exception/WriteException.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/compute/ComputeManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/compute/ComputeManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/compute/FileGraphPartition.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/compute/FileGraphPartition.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/compute/input/EdgesInput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/compute/input/EdgesInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/compute/input/MessageInput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/compute/input/MessageInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/compute/input/ReusablePointer.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/compute/input/ReusablePointer.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/compute/input/VertexInput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/compute/input/VertexInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/BuiltinGraphFactory.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/BuiltinGraphFactory.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/SuperstepStat.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/SuperstepStat.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/edge/DefaultEdge.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/edge/DefaultEdge.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/edge/DefaultEdges.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/edge/DefaultEdges.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/id/BytesId.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/id/BytesId.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/partition/HashPartitioner.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/partition/HashPartitioner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/partition/PartitionStat.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/partition/PartitionStat.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/partition/Partitioner.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/partition/Partitioner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/vertex/DefaultVertex.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/graph/vertex/DefaultVertex.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/EdgeFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/EdgeFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/ElementFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/ElementFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/GraphFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/GraphFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverter.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/IdUtil.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/IdUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/InputSourceFactory.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/InputSourceFactory.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/InputSplit.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/InputSplit.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/InputSplitFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/InputSplitFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/MasterInputHandler.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/MasterInputHandler.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/MasterInputManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/MasterInputManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/VertexFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/VertexFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/WorkerInputManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/WorkerInputManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/filter/DefaultInputFilter.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/filter/DefaultInputFilter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/filter/ExtractAllPropertyInputFilter.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/filter/ExtractAllPropertyInputFilter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeEdgeFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeEdgeFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeElementFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeElementFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeGraphFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeGraphFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeInputSplitFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeInputSplitFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeVertexFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeVertexFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/loader/FileEdgeFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/loader/FileEdgeFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/loader/FileElementFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/loader/FileElementFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/loader/FileInputSplit.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/loader/FileInputSplit.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/loader/FileVertxFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/loader/FileVertxFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/loader/LoaderFileInputSplitFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/loader/LoaderFileInputSplitFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/loader/LoaderGraphFetcher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/loader/LoaderGraphFetcher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/AbstractBufferedFileInput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/AbstractBufferedFileInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/AbstractBufferedFileOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/AbstractBufferedFileOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/BufferedFileInput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/BufferedFileInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/BufferedFileOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/BufferedFileOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/BufferedStreamInput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/BufferedStreamInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/BufferedStreamOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/BufferedStreamOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/CsvStructGraphOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/CsvStructGraphOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/IOFactory.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/IOFactory.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/JsonStructGraphOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/JsonStructGraphOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/OptimizedBytesInput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/OptimizedBytesInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/OptimizedBytesOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/OptimizedBytesOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/OutputFormat.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/OutputFormat.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/StreamGraphInput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/StreamGraphInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/StreamGraphOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/StreamGraphOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/StructGraphOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/StructGraphOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/StructRandomAccessOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/StructRandomAccessOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/UnsafeBytesInput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/UnsafeBytesInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/UnsafeBytesOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/io/UnsafeBytesOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/manager/Manager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/manager/Manager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/manager/Managers.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/manager/Managers.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/master/MasterService.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/master/MasterService.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/ClientFactory.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/ClientFactory.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/ClientHandler.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/ClientHandler.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/ConnectionId.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/ConnectionId.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/DataClientManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/DataClientManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/DataServerManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/DataServerManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/IOMode.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/IOMode.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/MessageHandler.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/MessageHandler.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/TransportClient.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/TransportClient.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/TransportConf.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/TransportConf.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/TransportHandler.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/TransportHandler.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/TransportProvider.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/TransportProvider.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/TransportServer.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/TransportServer.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/TransportState.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/TransportState.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/TransportUtil.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/TransportUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/buffer/FileRegionBuffer.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/buffer/FileRegionBuffer.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/buffer/NettyBuffer.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/buffer/NettyBuffer.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/buffer/NetworkBuffer.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/buffer/NetworkBuffer.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/buffer/NioBuffer.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/buffer/NioBuffer.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/connection/ConnectionManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/connection/ConnectionManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/connection/TransportConnectionManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/connection/TransportConnectionManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/AckMessage.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/AckMessage.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/DataMessage.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/DataMessage.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/FailMessage.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/FailMessage.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/FinishMessage.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/FinishMessage.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/Message.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/Message.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/MessageType.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/MessageType.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/PingMessage.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/PingMessage.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/PongMessage.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/PongMessage.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/RequestMessage.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/RequestMessage.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/ResponseMessage.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/ResponseMessage.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/StartMessage.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/message/StartMessage.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/AbstractNettyHandler.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/AbstractNettyHandler.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/BufAllocatorFactory.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/BufAllocatorFactory.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/ChannelFutureListenerOnWrite.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/ChannelFutureListenerOnWrite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/HeartbeatHandler.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/HeartbeatHandler.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyClientFactory.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyClientFactory.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyClientHandler.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyClientHandler.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyEventLoopUtil.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyEventLoopUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyProtocol.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyProtocol.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyServerHandler.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyServerHandler.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyTransportClient.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyTransportClient.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyTransportProvider.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyTransportProvider.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyTransportServer.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyTransportServer.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/ServerIdleHandler.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/ServerIdleHandler.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this
@@ -19,10 +18,9 @@
 
 package org.apache.hugegraph.computer.core.network.netty;
 
-import org.slf4j.Logger;
-
 import org.apache.hugegraph.computer.core.network.TransportUtil;
 import org.apache.hugegraph.util.Log;
+import org.slf4j.Logger;
 
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/codec/FrameDecoder.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/codec/FrameDecoder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/codec/MessageDecoder.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/codec/MessageDecoder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/codec/MessageEncoder.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/codec/MessageEncoder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/codec/PreciseFrameDecoder.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/netty/codec/PreciseFrameDecoder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/session/ClientSession.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/session/ClientSession.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/session/ServerSession.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/session/ServerSession.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/session/TransportSession.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/network/session/TransportSession.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/LimitedLogOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/LimitedLogOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/LogOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/LogOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hdfs/HdfsOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hdfs/HdfsOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hdfs/HdfsOutputMerger.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hdfs/HdfsOutputMerger.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hg/HugeGraphDoubleOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hg/HugeGraphDoubleOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hg/HugeGraphFloatOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hg/HugeGraphFloatOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hg/HugeGraphIdOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hg/HugeGraphIdOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hg/HugeGraphIntOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hg/HugeGraphIntOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hg/HugeGraphLongOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hg/HugeGraphLongOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hg/HugeGraphStringOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/output/hg/HugeGraphStringOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/MessageRecvBuffers.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/MessageRecvBuffers.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/MessageRecvManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/MessageRecvManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/MessageRecvPartition.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/MessageRecvPartition.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/MessageRecvPartitions.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/MessageRecvPartitions.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/MessageStat.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/MessageStat.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/edge/EdgeMessageRecvPartition.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/edge/EdgeMessageRecvPartition.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/edge/EdgeMessageRecvPartitions.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/edge/EdgeMessageRecvPartitions.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/message/ComputeMessageRecvPartition.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/message/ComputeMessageRecvPartition.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/message/ComputeMessageRecvPartitions.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/message/ComputeMessageRecvPartitions.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/vertex/VertexMessageRecvPartition.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/vertex/VertexMessageRecvPartition.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/vertex/VertexMessageRecvPartitions.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/receiver/vertex/VertexMessageRecvPartitions.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/rpc/AggregateRpcService.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/rpc/AggregateRpcService.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/rpc/InputSplitRpcService.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/rpc/InputSplitRpcService.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/rpc/MasterRpcManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/rpc/MasterRpcManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/rpc/WorkerRpcManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/rpc/WorkerRpcManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/MessageQueue.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/MessageQueue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/MessageSendBuffers.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/MessageSendBuffers.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/MessageSendManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/MessageSendManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/MessageSendPartition.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/MessageSendPartition.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/MessageSender.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/MessageSender.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/MultiQueue.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/MultiQueue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/QueuedMessage.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/QueuedMessage.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/QueuedMessageSender.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/QueuedMessageSender.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/WriteBuffer.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/WriteBuffer.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/WriteBuffers.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sender/WriteBuffers.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/BufferFileSorter.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/BufferFileSorter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/DefaultSorter.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/DefaultSorter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/HgkvFileSorter.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/HgkvFileSorter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/Sorter.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/Sorter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this
@@ -22,9 +21,9 @@ package org.apache.hugegraph.computer.core.sort;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.hugegraph.computer.core.io.RandomAccessInput;
 import org.apache.hugegraph.computer.core.sort.flusher.InnerSortFlusher;
 import org.apache.hugegraph.computer.core.sort.flusher.OuterSortFlusher;
-import org.apache.hugegraph.computer.core.io.RandomAccessInput;
 import org.apache.hugegraph.computer.core.sort.flusher.PeekableIterator;
 import org.apache.hugegraph.computer.core.store.entry.KvEntry;
 

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/CombinableSorterFlusher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/CombinableSorterFlusher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/CombineKvInnerSortFlusher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/CombineKvInnerSortFlusher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/CombineKvOuterSortFlusher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/CombineKvOuterSortFlusher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/CombineSubKvInnerSortFlusher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/CombineSubKvInnerSortFlusher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/CombineSubKvOuterSortFlusher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/CombineSubKvOuterSortFlusher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/InnerSortFlusher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/InnerSortFlusher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/KvInnerSortFlusher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/KvInnerSortFlusher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/KvOuterSortFlusher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/KvOuterSortFlusher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/OuterSortFlusher.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/OuterSortFlusher.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/PeekableIterator.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/PeekableIterator.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/PeekableIteratorAdaptor.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/flusher/PeekableIteratorAdaptor.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/merge/FileMerger.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/merge/FileMerger.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/merge/FileMergerImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/merge/FileMergerImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/InputSorter.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/InputSorter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/InputsSorter.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/InputsSorter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/InputsSorterImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/InputsSorterImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/JavaInputSorter.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/JavaInputSorter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/SubKvSorter.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/SubKvSorter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/AbstractInputsSorting.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/AbstractInputsSorting.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/HeapInputsSorting.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/HeapInputsSorting.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/InputsSorting.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/InputsSorting.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/LoserTreeInputsSorting.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/LoserTreeInputsSorting.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/RecvSortManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/RecvSortManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/SendSortManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/SendSortManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/SortManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/SortManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/SortingFactory.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/SortingFactory.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/SortingMode.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/SortingMode.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/EntryIterator.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/EntryIterator.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/FileGenerator.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/FileGenerator.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/FileManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/FileManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/KvEntryFileReader.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/KvEntryFileReader.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/KvEntryFileWriter.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/KvEntryFileWriter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/StoreManager.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/StoreManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/SuperstepFileGenerator.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/SuperstepFileGenerator.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/buffer/KvEntriesInput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/buffer/KvEntriesInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/buffer/KvEntriesWithFirstSubKvInput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/buffer/KvEntriesWithFirstSubKvInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/buffer/SubKvEntriesInput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/buffer/SubKvEntriesInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/AbstractKvEntry.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/AbstractKvEntry.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/CachedPointer.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/CachedPointer.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/DefaultKvEntry.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/DefaultKvEntry.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/EntriesUtil.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/EntriesUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/EntryInput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/EntryInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/EntryInputImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/EntryInputImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/EntryOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/EntryOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/EntryOutputImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/EntryOutputImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/InlinePointer.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/InlinePointer.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/KvEntry.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/KvEntry.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/KvEntryReader.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/KvEntryReader.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/KvEntryReaderImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/KvEntryReaderImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/KvEntryWithFirstSubKv.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/KvEntryWithFirstSubKv.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/KvEntryWriter.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/KvEntryWriter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/KvEntryWriterImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/KvEntryWriterImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/Pointer.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/Pointer.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/Range.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/entry/Range.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/bufferfile/BufferFileEntryBuilder.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/bufferfile/BufferFileEntryBuilder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/bufferfile/BufferFileEntryReader.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/bufferfile/BufferFileEntryReader.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/bufferfile/BufferFileSubEntryReader.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/bufferfile/BufferFileSubEntryReader.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/AbstractHgkvFile.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/AbstractHgkvFile.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/HgkvDir.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/HgkvDir.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/HgkvDirImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/HgkvDirImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/HgkvFile.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/HgkvFile.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/HgkvFileImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/HgkvFileImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this
@@ -23,7 +22,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.lang3.StringUtils;
-
 import org.apache.hugegraph.computer.core.common.exception.ComputerException;
 import org.apache.hugegraph.computer.core.io.IOFactory;
 import org.apache.hugegraph.computer.core.io.RandomAccessInput;

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/builder/BlockBuilder.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/builder/BlockBuilder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/builder/DataBlockBuilderImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/builder/DataBlockBuilderImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/builder/HgkvDirBuilderImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/builder/HgkvDirBuilderImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/builder/HgkvFileBuilder.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/builder/HgkvFileBuilder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/builder/HgkvFileBuilderImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/builder/HgkvFileBuilderImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/builder/IndexBlockBuilder.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/builder/IndexBlockBuilder.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/builder/IndexBlockBuilderImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/builder/IndexBlockBuilderImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/reader/HgkvDir4SubKvReaderImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/reader/HgkvDir4SubKvReaderImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/reader/HgkvDirReaderImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/reader/HgkvDirReaderImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this
@@ -26,10 +25,10 @@ import java.util.NoSuchElementException;
 
 import org.apache.hugegraph.computer.core.common.exception.ComputerException;
 import org.apache.hugegraph.computer.core.store.EntryIterator;
-import org.apache.hugegraph.computer.core.store.entry.KvEntry;
-import org.apache.hugegraph.computer.core.store.file.hgkvfile.HgkvDirImpl;
 import org.apache.hugegraph.computer.core.store.KvEntryFileReader;
+import org.apache.hugegraph.computer.core.store.entry.KvEntry;
 import org.apache.hugegraph.computer.core.store.file.hgkvfile.HgkvDir;
+import org.apache.hugegraph.computer.core.store.file.hgkvfile.HgkvDirImpl;
 import org.apache.hugegraph.computer.core.store.file.hgkvfile.HgkvFile;
 
 public class HgkvDirReaderImpl implements KvEntryFileReader {

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/reader/HgkvFileReaderImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/hgkvfile/reader/HgkvFileReaderImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/select/DefaultSelectedFiles.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/select/DefaultSelectedFiles.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/select/DisperseEvenlySelector.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/select/DisperseEvenlySelector.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/select/InputFilesSelector.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/select/InputFilesSelector.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/select/SelectedFiles.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/select/SelectedFiles.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/seqfile/BitsFileReader.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/seqfile/BitsFileReader.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/seqfile/BitsFileReaderImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/seqfile/BitsFileReaderImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/seqfile/BitsFileWriter.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/seqfile/BitsFileWriter.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/seqfile/BitsFileWriterImpl.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/seqfile/BitsFileWriterImpl.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/seqfile/ValueFile.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/seqfile/ValueFile.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/seqfile/ValueFileInput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/seqfile/ValueFileInput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/seqfile/ValueFileOutput.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/store/file/seqfile/ValueFileOutput.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/util/ComputerContextUtil.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/util/ComputerContextUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/util/Consumers.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/util/Consumers.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/util/FileUtil.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/util/FileUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/util/JsonUtil.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/util/JsonUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/util/SerializeUtil.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/util/SerializeUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/util/ShutdownHook.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/util/ShutdownHook.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/util/StringEncoding.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/util/StringEncoding.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/worker/WorkerService.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/worker/WorkerService.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/worker/WorkerStat.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/worker/WorkerStat.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-core/src/main/java/org/apache/hugegraph/computer/core/worker/load/LoadService.java
+++ b/computer-core/src/main/java/org/apache/hugegraph/computer/core/worker/load/LoadService.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-dist/src/assembly/dataset/load-movie-data.groovy
+++ b/computer-dist/src/assembly/dataset/load-movie-data.groovy
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-dist/src/assembly/dataset/schema.groovy
+++ b/computer-dist/src/assembly/dataset/schema.groovy
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-dist/src/assembly/travis/install-hugegraph-from-source.sh
+++ b/computer-dist/src/assembly/travis/install-hugegraph-from-source.sh
@@ -26,12 +26,11 @@ COMMIT_ID=$1
 HUGEGRAPH_GIT_URL="https://github.com/apache/hugegraph.git"
 
 git clone --depth 300 ${HUGEGRAPH_GIT_URL}
-cd apache-hugegraph
+cd hugegraph
 git checkout ${COMMIT_ID}
 mvn package -DskipTests
 mv apache-hugegraph-*.tar.gz ../
 cd ../
-rm -rf apache-hugegraph
 tar -zxf apache-hugegraph-*.tar.gz
 
 cd "$(find apache-hugegraph-* | head -1)"

--- a/computer-dist/src/assembly/travis/install-hugegraph-from-source.sh
+++ b/computer-dist/src/assembly/travis/install-hugegraph-from-source.sh
@@ -25,15 +25,19 @@ fi
 COMMIT_ID=$1
 HUGEGRAPH_GIT_URL="https://github.com/apache/hugegraph.git"
 
-git clone --depth 300 ${HUGEGRAPH_GIT_URL}
+git clone --depth 100 ${HUGEGRAPH_GIT_URL}
 cd hugegraph
 git checkout ${COMMIT_ID}
 mvn package -DskipTests
+
 mv apache-hugegraph-*.tar.gz ../
 cd ../
-tar -zxf apache-hugegraph-*.tar.gz
-
+rm -rf hugegraph
+tar zxf apache-hugegraph-*.tar.gz
+rm apache-hugegraph-*.tar.gz
 cd "$(find apache-hugegraph-* | head -1)"
+chmod -R 755 bin/
+
 bin/init-store.sh || exit 1
-bin/start-hugegraph.sh || exit 1
+bin/start-hugegraph.sh || cat logs/hugegraph-server.log
 cd ../

--- a/computer-dist/src/assembly/travis/install-hugegraph-from-source.sh
+++ b/computer-dist/src/assembly/travis/install-hugegraph-from-source.sh
@@ -26,15 +26,15 @@ COMMIT_ID=$1
 HUGEGRAPH_GIT_URL="https://github.com/apache/hugegraph.git"
 
 git clone --depth 300 ${HUGEGRAPH_GIT_URL}
-cd hugegraph
+cd apache-hugegraph
 git checkout ${COMMIT_ID}
 mvn package -DskipTests
-mv hugegraph-*.tar.gz ../
+mv apache-hugegraph-*.tar.gz ../
 cd ../
-rm -rf hugegraph
-tar -zxf hugegraph-*.tar.gz
+rm -rf apache-hugegraph
+tar -zxf apache-hugegraph-*.tar.gz
 
-cd "$(find hugegraph-* | head -1)"
+cd "$(find apache-hugegraph-* | head -1)"
 bin/init-store.sh || exit 1
 bin/start-hugegraph.sh || exit 1
 cd ../

--- a/computer-dist/src/assembly/travis/load-data-into-hugegraph.sh
+++ b/computer-dist/src/assembly/travis/load-data-into-hugegraph.sh
@@ -35,7 +35,8 @@ cd ../../
 wget http://files.grouplens.org/datasets/movielens/ml-latest-small.zip
 unzip -d ${DATASET_DIR} ml-latest-small.zip
 
-hugegraph-toolchain/hugegraph-loader/apache-hugegraph-loader-*/bin/hugegraph-loader.sh -g hugegraph-f ${DATASET_DIR}/struct.json -s ${DATASET_DIR}/schema.groovy || exit 1
+hugegraph-toolchain/hugegraph-loader/apache-hugegraph-loader-*/bin/hugegraph-loader.sh \
+-g hugegraph -f ${DATASET_DIR}/struct.json -s ${DATASET_DIR}/schema.groovy || exit 1
 
 # load dataset to hdfs
 sort -t , -k1n -u "${DATASET_DIR}"/ml-latest-small/ratings.csv | cut -d "," -f 1 > "${DATASET_DIR}"/ml-latest-small/user_id.csv || exit 1

--- a/computer-dist/src/assembly/travis/load-data-into-hugegraph.sh
+++ b/computer-dist/src/assembly/travis/load-data-into-hugegraph.sh
@@ -29,13 +29,13 @@ cd hugegraph-toolchain
 mvn install -pl hugegraph-client,hugegraph-loader -am -DskipTests -ntp
 
 cd hugegraph-loader
-tar -zxf hugegraph-loader-*.tar.gz || exit 1
+tar -zxf apache-hugegraph-loader-*.tar.gz || exit 1
 cd ../../
 
 wget http://files.grouplens.org/datasets/movielens/ml-latest-small.zip
 unzip -d ${DATASET_DIR} ml-latest-small.zip
 
-hugegraph-toolchain/hugegraph-loader/hugegraph-loader-*/bin/hugegraph-loader.sh -g hugegraph -f ${DATASET_DIR}/struct.json -s ${DATASET_DIR}/schema.groovy || exit 1
+hugegraph-toolchain/hugegraph-loader/apache-hugegraph-loader-*/bin/hugegraph-loader.sh -g hugegraph-f ${DATASET_DIR}/struct.json -s ${DATASET_DIR}/schema.groovy || exit 1
 
 # load dataset to hdfs
 sort -t , -k1n -u "${DATASET_DIR}"/ml-latest-small/ratings.csv | cut -d "," -f 1 > "${DATASET_DIR}"/ml-latest-small/user_id.csv || exit 1

--- a/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/ComputerDriver.java
+++ b/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/ComputerDriver.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/ComputerDriverException.java
+++ b/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/ComputerDriverException.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/DefaultJobState.java
+++ b/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/DefaultJobState.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/JobObserver.java
+++ b/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/JobObserver.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/JobState.java
+++ b/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/JobState.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/JobStatus.java
+++ b/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/JobStatus.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/SuperstepStat.java
+++ b/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/SuperstepStat.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/config/DriverConfigOption.java
+++ b/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/config/DriverConfigOption.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/util/JsonUtil.java
+++ b/computer-driver/src/main/java/org/apache/hugegraph/computer/driver/util/JsonUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s-operator/crd-generate/api/v1/groupversion_info.go
+++ b/computer-k8s-operator/crd-generate/api/v1/groupversion_info.go
@@ -1,6 +1,4 @@
 /*
-Copyright 2017 HugeGraph Authors
-
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements. See the NOTICE file distributed with this
 work for additional information regarding copyright ownership. The ASF

--- a/computer-k8s-operator/crd-generate/api/v1/hugegraphcomputerjob_types.go
+++ b/computer-k8s-operator/crd-generate/api/v1/hugegraphcomputerjob_types.go
@@ -1,6 +1,4 @@
 /*
-Copyright 2017 HugeGraph Authors
-
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements. See the NOTICE file distributed with this
 work for additional information regarding copyright ownership. The ASF

--- a/computer-k8s-operator/crd-generate/cmd/generate.go
+++ b/computer-k8s-operator/crd-generate/cmd/generate.go
@@ -1,6 +1,4 @@
 /*
-Copyright 2017 HugeGraph Authors
-
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements. See the NOTICE file distributed with this
 work for additional information regarding copyright ownership. The ASF

--- a/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/OperatorEntrypoint.java
+++ b/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/OperatorEntrypoint.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/common/AbstractController.java
+++ b/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/common/AbstractController.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/common/MatchWithMsg.java
+++ b/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/common/MatchWithMsg.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/common/OperatorRequest.java
+++ b/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/common/OperatorRequest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/common/OperatorResult.java
+++ b/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/common/OperatorResult.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/common/WorkQueue.java
+++ b/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/common/WorkQueue.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/config/OperatorOptions.java
+++ b/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/config/OperatorOptions.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/controller/ComputerJobComponent.java
+++ b/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/controller/ComputerJobComponent.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/controller/ComputerJobController.java
+++ b/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/controller/ComputerJobController.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/controller/ComputerJobDeployer.java
+++ b/computer-k8s-operator/src/main/java/org/apache/hugegraph/computer/k8s/operator/controller/ComputerJobDeployer.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s/src/main/java/org/apache/hugegraph/computer/k8s/Constants.java
+++ b/computer-k8s/src/main/java/org/apache/hugegraph/computer/k8s/Constants.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s/src/main/java/org/apache/hugegraph/computer/k8s/config/KubeDriverOptions.java
+++ b/computer-k8s/src/main/java/org/apache/hugegraph/computer/k8s/config/KubeDriverOptions.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s/src/main/java/org/apache/hugegraph/computer/k8s/config/KubeSpecOptions.java
+++ b/computer-k8s/src/main/java/org/apache/hugegraph/computer/k8s/config/KubeSpecOptions.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s/src/main/java/org/apache/hugegraph/computer/k8s/crd/model/HugeGraphComputerJob.java
+++ b/computer-k8s/src/main/java/org/apache/hugegraph/computer/k8s/crd/model/HugeGraphComputerJob.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s/src/main/java/org/apache/hugegraph/computer/k8s/crd/model/HugeGraphComputerJobList.java
+++ b/computer-k8s/src/main/java/org/apache/hugegraph/computer/k8s/crd/model/HugeGraphComputerJobList.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s/src/main/java/org/apache/hugegraph/computer/k8s/driver/KubernetesDriver.java
+++ b/computer-k8s/src/main/java/org/apache/hugegraph/computer/k8s/driver/KubernetesDriver.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-k8s/src/main/java/org/apache/hugegraph/computer/k8s/util/KubeUtil.java
+++ b/computer-k8s/src/main/java/org/apache/hugegraph/computer/k8s/util/KubeUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/AlgorithmTestBase.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/AlgorithmTestBase.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/AlgorithmTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/AlgorithmTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/betweenness/BetweennessCentralityTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/betweenness/BetweennessCentralityTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/closeness/ClosenessCentralityTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/closeness/ClosenessCentralityTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/degree/DegreeCentralityTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/degree/DegreeCentralityTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/pagerank/PageRankTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/pagerank/PageRankTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/community/cc/ClusteringCoefficientTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/community/cc/ClusteringCoefficientTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/community/kcore/KcoreTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/community/kcore/KcoreTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/community/lpa/LpaTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/community/lpa/LpaTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/community/trianglecount/TriangleCountTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/community/trianglecount/TriangleCountTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/community/wcc/WccTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/community/wcc/WccTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/RingsDetectionTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/RingsDetectionTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/RingsDetectionWithFilterTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/RingsDetectionWithFilterTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/allocator/AllocatorTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/allocator/AllocatorTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/allocator/DefaultAllocatorTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/allocator/DefaultAllocatorTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/allocator/RecyclersTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/allocator/RecyclersTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/bsp/BspEventTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/bsp/BspEventTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/bsp/BspTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/bsp/BspTestSuite.java
@@ -1,5 +1,4 @@
 /*
- *  Copyright 2017 HugeGraph Authors
  *
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/bsp/EtcdBspTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/bsp/EtcdBspTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/bsp/EtcdClientTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/bsp/EtcdClientTest.java
@@ -1,5 +1,4 @@
 /*
- *  Copyright 2017 HugeGraph Authors
  *
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/CombinerTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/CombinerTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/DoubleValueSumCombinerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/DoubleValueSumCombinerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/FloatValueSumCombinerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/FloatValueSumCombinerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/IntValueSumCombinerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/IntValueSumCombinerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/LongValueSumCombinerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/LongValueSumCombinerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/MergeNewPropertiesCombinerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/MergeNewPropertiesCombinerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/MergeOldPropertiesCombinerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/MergeOldPropertiesCombinerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/OverwriteCombinerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/OverwriteCombinerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/PointerCombinerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/PointerCombinerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/ValueMaxCombinerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/ValueMaxCombinerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/ValueMinCombinerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/combiner/ValueMinCombinerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/common/CommonTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/common/CommonTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/common/ContainerInfoTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/common/ContainerInfoTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/common/ExceptionTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/common/ExceptionTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/common/FakeMasterComputation.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/common/FakeMasterComputation.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/compute/ComputeManagerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/compute/ComputeManagerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/compute/ComputeTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/compute/ComputeTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/compute/MockComputation.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/compute/MockComputation.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/compute/MockMessageSender.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/compute/MockMessageSender.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/compute/input/EdgesInputTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/compute/input/EdgesInputTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/compute/input/MessageInputTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/compute/input/MessageInputTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/compute/input/ResuablePointerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/compute/input/ResuablePointerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/config/ConfigTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/config/ConfigTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/config/DefaultConfigTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/config/DefaultConfigTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/BuiltinGraphFactoryTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/BuiltinGraphFactoryTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/DefaultEdgeTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/DefaultEdgeTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/DefaultPropertiesTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/DefaultPropertiesTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/GraphTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/GraphTestSuite.java
@@ -1,6 +1,5 @@
 /*
  *
- *  Copyright 2017 HugeGraph Authors
  *
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/SuperstepStatTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/SuperstepStatTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/id/BytesIdTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/id/BytesIdTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/id/IdFactoryTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/id/IdFactoryTest.java
@@ -1,6 +1,5 @@
 /*
  *
- *  Copyright 2017 HugeGraph Authors
  *
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/id/IdTypeTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/id/IdTypeTest.java
@@ -1,6 +1,5 @@
 /*
  *
- *  Copyright 2017 HugeGraph Authors
  *
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/partition/HashPartitionerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/partition/HashPartitionerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/partition/PartitionStatTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/partition/PartitionStatTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/BooleanValueTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/BooleanValueTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/DoubleValueTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/DoubleValueTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/FloatValueTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/FloatValueTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/IdListListTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/IdListListTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/IdValueListTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/IdValueListTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/IdValueTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/IdValueTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/IntValueTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/IntValueTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/ListValueTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/ListValueTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/LongValueTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/LongValueTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/NullValueTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/NullValueTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/StringValueTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/StringValueTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/ValueTypeTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/ValueTypeTest.java
@@ -1,6 +1,5 @@
 /*
  *
- *  Copyright 2017 HugeGraph Authors
  *
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/FileInputSplitTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/FileInputSplitTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverterTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverterTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/InputSplitDataTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/InputSplitDataTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/InputSplitTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/InputSplitTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/InputTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/InputTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/MockMasterInputManager.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/MockMasterInputManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/MockRpcClient.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/MockRpcClient.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/MockWorkerInputManager.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/MockWorkerInputManager.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/BufferedFileTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/BufferedFileTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/BufferedStreamTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/BufferedStreamTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/CsvStructGraphOutputTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/CsvStructGraphOutputTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/IOTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/IOTestSuite.java
@@ -1,6 +1,5 @@
 /*
  *
- *  Copyright 2017 HugeGraph Authors
  *
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/JsonStructGraphOutputTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/JsonStructGraphOutputTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/MockRankComputation.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/MockRankComputation.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/OptimizedUnsafeBytesTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/OptimizedUnsafeBytesTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/StreamGraphOutputInputTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/StreamGraphOutputInputTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/StructRandomAccessOutputTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/StructRandomAccessOutputTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/UnsafeBytesTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/io/UnsafeBytesTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/ConnectionIdTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/ConnectionIdTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/DataServerManagerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/DataServerManagerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/MockClientHandler.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/MockClientHandler.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/MockMessageHandler.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/MockMessageHandler.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/MockUnDecodeMessage.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/MockUnDecodeMessage.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/NetworkTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/NetworkTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/TransportUtilTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/TransportUtilTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/buffer/NetworkBufferTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/buffer/NetworkBufferTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/connection/ConnectionManagerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/connection/ConnectionManagerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/netty/AbstractNetworkTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/netty/AbstractNetworkTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/netty/HeartbeatHandlerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/netty/HeartbeatHandlerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyClientFactoryTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyClientFactoryTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyEncodeDecodeHandlerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyEncodeDecodeHandlerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyTransportClientTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyTransportClientTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyTransportServerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/netty/NettyTransportServerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/session/TransportSessionTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/network/session/TransportSessionTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/receiver/MessageRecvBuffersTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/receiver/MessageRecvBuffersTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/receiver/MessageRecvManagerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/receiver/MessageRecvManagerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/receiver/ReceiverTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/receiver/ReceiverTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/receiver/ReceiverUtil.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/receiver/ReceiverUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/receiver/edge/EdgeMessageRecvPartitionTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/receiver/edge/EdgeMessageRecvPartitionTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/receiver/message/ComputeMessageRecvPartitionTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/receiver/message/ComputeMessageRecvPartitionTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/receiver/vertex/VertexMessageRecvPartitionTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/receiver/vertex/VertexMessageRecvPartitionTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/MessageQueueTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/MessageQueueTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/MessageSendBuffersTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/MessageSendBuffersTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/MessageSendManagerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/MessageSendManagerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/MockTransportClient.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/MockTransportClient.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/MultiQueueTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/MultiQueueTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/QueuedMessageSenderTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/QueuedMessageSenderTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/QueuedMessageTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/QueuedMessageTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/SenderTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/SenderTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/WriteBufferTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/WriteBufferTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/WriteBuffersTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sender/WriteBuffersTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/SorterTestUtil.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/SorterTestUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/combiner/MockIntSumCombiner.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/combiner/MockIntSumCombiner.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/EmptyFlusherTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/EmptyFlusherTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/FlusherTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/FlusherTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/SortLargeDataTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/SortLargeDataTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/SorterTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/SorterTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this
@@ -26,18 +25,6 @@ import java.util.List;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hugegraph.computer.core.combiner.IntValueSumCombiner;
-import org.apache.hugegraph.computer.core.sort.flusher.CombineKvInnerSortFlusher;
-import org.apache.hugegraph.computer.core.sort.flusher.CombineKvOuterSortFlusher;
-import org.apache.hugegraph.computer.core.sort.flusher.CombineSubKvInnerSortFlusher;
-import org.apache.hugegraph.computer.core.sort.flusher.CombineSubKvOuterSortFlusher;
-import org.apache.hugegraph.computer.core.sort.flusher.InnerSortFlusher;
-import org.apache.hugegraph.computer.core.sort.flusher.OuterSortFlusher;
-import org.apache.hugegraph.computer.core.store.StoreTestUtil;
-import org.apache.hugegraph.computer.core.util.FileUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import org.apache.hugegraph.computer.core.combiner.PointerCombiner;
 import org.apache.hugegraph.computer.core.common.Constants;
 import org.apache.hugegraph.computer.core.config.ComputerOptions;
@@ -49,8 +36,15 @@ import org.apache.hugegraph.computer.core.io.IOFactory;
 import org.apache.hugegraph.computer.core.io.RandomAccessInput;
 import org.apache.hugegraph.computer.core.sort.Sorter;
 import org.apache.hugegraph.computer.core.sort.SorterTestUtil;
+import org.apache.hugegraph.computer.core.sort.flusher.CombineKvInnerSortFlusher;
+import org.apache.hugegraph.computer.core.sort.flusher.CombineKvOuterSortFlusher;
+import org.apache.hugegraph.computer.core.sort.flusher.CombineSubKvInnerSortFlusher;
+import org.apache.hugegraph.computer.core.sort.flusher.CombineSubKvOuterSortFlusher;
+import org.apache.hugegraph.computer.core.sort.flusher.InnerSortFlusher;
+import org.apache.hugegraph.computer.core.sort.flusher.OuterSortFlusher;
 import org.apache.hugegraph.computer.core.store.EntryIterator;
 import org.apache.hugegraph.computer.core.store.KvEntryFileReader;
+import org.apache.hugegraph.computer.core.store.StoreTestUtil;
 import org.apache.hugegraph.computer.core.store.buffer.KvEntriesInput;
 import org.apache.hugegraph.computer.core.store.entry.EntriesUtil;
 import org.apache.hugegraph.computer.core.store.entry.KvEntry;
@@ -59,10 +53,14 @@ import org.apache.hugegraph.computer.core.store.file.hgkvfile.HgkvDirImpl;
 import org.apache.hugegraph.computer.core.store.file.hgkvfile.reader.HgkvDirReaderImpl;
 import org.apache.hugegraph.computer.core.store.file.select.DisperseEvenlySelector;
 import org.apache.hugegraph.computer.core.store.file.select.InputFilesSelector;
-
+import org.apache.hugegraph.computer.core.util.FileUtil;
 import org.apache.hugegraph.computer.suite.unit.UnitTestBase;
 import org.apache.hugegraph.iterator.CIter;
 import org.apache.hugegraph.testutil.Assert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/SorterTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorter/SorterTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/InputsSortingTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/InputsSortingTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/SortingTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/SortingTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/TestData.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/sort/sorting/TestData.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/BitFileTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/BitFileTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/EntriesUtilTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/EntriesUtilTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/EntryOutputTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/EntryOutputTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/FileManagerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/FileManagerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/HgkvDirTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/HgkvDirTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this
@@ -25,11 +24,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import org.apache.hugegraph.computer.core.config.ComputerOptions;
 import org.apache.hugegraph.computer.core.config.Config;
 import org.apache.hugegraph.computer.core.store.entry.KvEntry;
@@ -40,6 +34,11 @@ import org.apache.hugegraph.computer.core.store.file.hgkvfile.builder.HgkvDirBui
 import org.apache.hugegraph.computer.core.store.file.hgkvfile.reader.HgkvDirReaderImpl;
 import org.apache.hugegraph.computer.suite.unit.UnitTestBase;
 import org.apache.hugegraph.testutil.Assert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
 import com.google.common.collect.ImmutableList;
 
 public class HgkvDirTest {

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/HgkvFileTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/HgkvFileTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/PointerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/PointerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/StoreTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/StoreTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/StoreTestUtil.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/StoreTestUtil.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/ValueFileTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/store/ValueFileTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/util/ComputerContextUtilTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/util/ComputerContextUtilTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/util/JsonUtilTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/util/JsonUtilTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/util/SerializeUtilTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/util/SerializeUtilTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this
@@ -24,9 +23,8 @@ import java.util.List;
 
 import org.apache.hugegraph.computer.core.graph.id.BytesId;
 import org.apache.hugegraph.computer.core.graph.id.Id;
-import org.junit.Test;
-
 import org.apache.hugegraph.testutil.Assert;
+import org.junit.Test;
 
 public class SerializeUtilTest {
 

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/util/UtilTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/util/UtilTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/MockComputation.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/MockComputation.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/MockComputation2.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/MockComputation2.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/MockComputationParams.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/MockComputationParams.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/MockMasterComputation.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/MockMasterComputation.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/MockMasterComputation2.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/MockMasterComputation2.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/MockWorkerService.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/MockWorkerService.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/WorkerServiceTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/WorkerServiceTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/WorkerStatTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/WorkerStatTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/WorkerTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/worker/WorkerTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/dist/ComputerDistTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/dist/ComputerDistTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/dist/HugeGraphComputerTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/dist/HugeGraphComputerTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/driver/ComputerOptionsTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/driver/ComputerOptionsTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/driver/DriverTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/driver/DriverTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/driver/DriverTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/driver/DriverTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/k8s/AbstractK8sTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/k8s/AbstractK8sTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/k8s/K8sTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/k8s/K8sTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/k8s/KubernetesDriverTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/k8s/KubernetesDriverTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/k8s/MiniKubeTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/k8s/MiniKubeTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/k8s/OperatorTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/k8s/OperatorTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/integrate/IntegrateTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/integrate/IntegrateTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/integrate/MockComputation.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/integrate/MockComputation.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/integrate/SenderIntegrateTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/integrate/SenderIntegrateTest.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestSuite.java
@@ -1,5 +1,4 @@
 /*
- * Copyright 2017 HugeGraph Authors
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -43,7 +57,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <top.level.dir>${project.basedir}/..</top.level.dir>
         <release.name>hugegraph-computer</release.name>
-        <final.name>${release.name}-${project.version}</final.name>
+        <final.name>apache-${release.name}-incubating-${project.version}</final.name>
         <compiler.source>11</compiler.source>
         <compiler.target>11</compiler.target>
         <shell-executable>bash</shell-executable>
@@ -262,6 +276,8 @@
                         <exclude>**/dependency-reduced-pom.xml</exclude>
                         <exclude>**/target/*</exclude>
                         <exclude>.github/**/*</exclude>
+                        <exclude>**/.flattened-pom.xml</exclude>
+                        <exclude>**/zz_generated.deepcopy.go</exclude>
                     </excludes>
                     <consoleOutput>true</consoleOutput>
                 </configuration>


### PR DESCRIPTION
* Rename binary package name
* Remove `Copyright 2017 HugeGraph Authors`
* Exclude some license check
* Update server commit id