### PR TITLE
chore：change etcd url only for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       TRAVIS_DIR: computer-dist/src/assembly/travis
       KUBERNETES_VERSION: 1.20.1
       HUGEGRAPH_SERVER_COMMIT_ID: d01c8737d7d5909119671953521f1401dcd1a188
+      BSP_ETCD_URL: http://localhost:2579
 
     steps:
       - name: Checkout

--- a/computer-dist/src/assembly/travis/start-etcd.sh
+++ b/computer-dist/src/assembly/travis/start-etcd.sh
@@ -26,5 +26,5 @@ chmod a+x ${TRAVIS_DIR}/etcd
 ${TRAVIS_DIR}/etcd/etcd --name etcd-test \
     --initial-advertise-peer-urls http://localhost:2580 \
     --listen-peer-urls http://localhost:2580 \
-    --advertise-client-urls http://localhost:2579 \
-    --listen-client-urls http://localhost:2579 &
+    --advertise-client-urls ${BSP_ETCD_URL} \
+    --listen-client-urls ${BSP_ETCD_URL} &

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/k8s/AbstractK8sTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/k8s/AbstractK8sTest.java
@@ -74,14 +74,11 @@ public abstract class AbstractK8sTest {
 
     static {
         OptionSpace.register("computer",
-                             "org.apache.hugegraph.computer.core.config." +
-                             "ComputerOptions");
+                             "org.apache.hugegraph.computer.core.config.ComputerOptions");
         OptionSpace.register("computer-k8s-driver",
-                             "org.apache.hugegraph.computer.k8s.config" +
-                             ".KubeDriverOptions");
+                             "org.apache.hugegraph.computer.k8s.config.KubeDriverOptions");
         OptionSpace.register("computer-k8s-spec",
-                             "org.apache.hugegraph.computer.k8s.config" +
-                             ".KubeSpecOptions");
+                             "org.apache.hugegraph.computer.k8s.config.KubeSpecOptions");
     }
 
     protected void updateOptions(String key, Object value) {

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/integrate/IntegrateTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/integrate/IntegrateTestSuite.java
@@ -44,8 +44,7 @@ public class IntegrateTestSuite {
 
         // Don't forget to register options
         OptionSpace.register("computer",
-                             "org.apache.hugegraph.computer.core.config." +
-                             "ComputerOptions");
+                             "org.apache.hugegraph.computer.core.config.ComputerOptions");
         OptionSpace.register("computer-rpc", "org.apache.hugegraph.config.RpcOptions");
 
         String etcdUrl = System.getenv("BSP_ETCD_URL");

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/integrate/IntegrateTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/integrate/IntegrateTestSuite.java
@@ -49,6 +49,6 @@ public class IntegrateTestSuite {
                              "org.apache.hugegraph.config.RpcOptions");
 
         Whitebox.setInternalState(ComputerOptions.BSP_ETCD_ENDPOINTS,
-                                  "defaultValue", "http://localhost:2579");
+                                  "defaultValue", "http://localhost:2379");
     }
 }

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/integrate/IntegrateTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/integrate/IntegrateTestSuite.java
@@ -17,6 +17,7 @@
 
 package org.apache.hugegraph.computer.suite.integrate;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hugegraph.computer.core.config.ComputerOptions;
 import org.apache.hugegraph.config.OptionSpace;
 import org.apache.hugegraph.testutil.Whitebox;
@@ -48,7 +49,12 @@ public class IntegrateTestSuite {
         OptionSpace.register("computer-rpc",
                              "org.apache.hugegraph.config.RpcOptions");
 
-        Whitebox.setInternalState(ComputerOptions.BSP_ETCD_ENDPOINTS,
-                                  "defaultValue", "http://localhost:2379");
+        String etcdUrl = System.getenv("BSP_ETCD_URL");
+        if (StringUtils.isNotBlank(etcdUrl)) {
+            Whitebox.setInternalState(ComputerOptions.BSP_ETCD_ENDPOINTS,
+                                      "defaultValue",
+                                      etcdUrl);
+        }
+
     }
 }

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/integrate/IntegrateTestSuite.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/integrate/IntegrateTestSuite.java
@@ -46,14 +46,12 @@ public class IntegrateTestSuite {
         OptionSpace.register("computer",
                              "org.apache.hugegraph.computer.core.config." +
                              "ComputerOptions");
-        OptionSpace.register("computer-rpc",
-                             "org.apache.hugegraph.config.RpcOptions");
+        OptionSpace.register("computer-rpc", "org.apache.hugegraph.config.RpcOptions");
 
         String etcdUrl = System.getenv("BSP_ETCD_URL");
         if (StringUtils.isNotBlank(etcdUrl)) {
             Whitebox.setInternalState(ComputerOptions.BSP_ETCD_ENDPOINTS,
-                                      "defaultValue",
-                                      etcdUrl);
+                                      "defaultValue", etcdUrl);
         }
 
     }

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
@@ -81,7 +81,7 @@ public class UnitTestBase {
 
         Whitebox.setInternalState(ComputerOptions.BSP_ETCD_ENDPOINTS,
                 "defaultValue",
-                "http://localhost:2579");
+                "http://localhost:2379");
         Whitebox.setInternalState(ComputerOptions.HUGEGRAPH_URL,
                 "defaultValue",
                 "http://127.0.0.1:8080");

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
@@ -56,6 +56,7 @@ import org.apache.hugegraph.testutil.Whitebox;
 import org.apache.hugegraph.util.E;
 import org.apache.hugegraph.util.Log;
 import org.apache.logging.log4j.LogManager;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
 
@@ -72,6 +73,14 @@ public class UnitTestBase {
 
     protected static void clearAll() {
         client().graphs().clearGraph(GRAPH, "I'm sure to delete all data");
+    }
+
+    @AfterClass
+    public static synchronized void cleanup() {
+        if (CLIENT != null) {
+            CLIENT.close();
+            CLIENT = null;
+        }
     }
 
     @BeforeClass

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
@@ -76,7 +76,7 @@ public class UnitTestBase {
     }
 
     @AfterClass
-    public static synchronized void cleanup() {
+    public static void cleanup() {
         if (CLIENT != null) {
             CLIENT.close();
             CLIENT = null;

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
@@ -92,8 +92,7 @@ public class UnitTestBase {
         String etcdUrl = System.getenv("BSP_ETCD_URL");
         if (StringUtils.isNotBlank(etcdUrl)) {
             Whitebox.setInternalState(ComputerOptions.BSP_ETCD_ENDPOINTS,
-                                      "defaultValue",
-                                      etcdUrl);
+                                      "defaultValue", etcdUrl);
         }
 
         Whitebox.setInternalState(ComputerOptions.HUGEGRAPH_URL,

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hugegraph.computer.core.common.ComputerContext;
 import org.apache.hugegraph.computer.core.common.Constants;
 import org.apache.hugegraph.computer.core.common.exception.ComputerException;
@@ -79,9 +80,13 @@ public class UnitTestBase {
 
         LOG.info("Setup for UnitTestSuite of hugegraph-computer");
 
-        Whitebox.setInternalState(ComputerOptions.BSP_ETCD_ENDPOINTS,
-                "defaultValue",
-                "http://localhost:2379");
+        String etcdUrl = System.getenv("BSP_ETCD_URL");
+        if (StringUtils.isNotBlank(etcdUrl)) {
+            Whitebox.setInternalState(ComputerOptions.BSP_ETCD_ENDPOINTS,
+                                      "defaultValue",
+                                      etcdUrl);
+        }
+
         Whitebox.setInternalState(ComputerOptions.HUGEGRAPH_URL,
                 "defaultValue",
                 "http://127.0.0.1:8080");

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
@@ -75,14 +75,6 @@ public class UnitTestBase {
         client().graphs().clearGraph(GRAPH, "I'm sure to delete all data");
     }
 
-    @AfterClass
-    public static void cleanup() {
-        if (CLIENT != null) {
-            CLIENT.close();
-            CLIENT = null;
-        }
-    }
-
     @BeforeClass
     public static void init() throws ClassNotFoundException {
         Runtime.getRuntime().addShutdownHook(new Thread(LogManager::shutdown));
@@ -138,14 +130,20 @@ public class UnitTestBase {
         Class.forName(IdType.class.getName());
         // Don't forget to register options
         OptionSpace.register("computer",
-                "org.apache.hugegraph.computer.core.config." +
-                        "ComputerOptions");
-        OptionSpace.register("computer-rpc",
-                "org.apache.hugegraph.config.RpcOptions");
+                             "org.apache.hugegraph.computer.core.config.ComputerOptions");
+        OptionSpace.register("computer-rpc", "org.apache.hugegraph.config.RpcOptions");
 
         UnitTestBase.updateOptions(
                 ComputerOptions.ALGORITHM_RESULT_CLASS, LongValue.class.getName()
         );
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        if (CLIENT != null) {
+            CLIENT.close();
+            CLIENT = null;
+        }
     }
 
     public static void assertIdEqualAfterWriteAndRead(Id oldId)


### PR DESCRIPTION
## Purpose of the PR

Change etcd url only for ci, otherwise, we use the default address to local test

## Main Changes

Change etcd url only for ci

## Verifying these changes

<!-- Please pick either of the following options -->

- This change is a trivial rework / code cleanup without any test coverage.

*(or)*

- This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

- This change added tests and can be verified as follows:
  
  *(for example:)*
  - *Add UT.*


## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - NO Need` <!-- Your PR changes don't impact/need docs -->
