### PR TITLE
refactor(api): ListValue.getFirst() replaces ListValue.get(0)

### DIFF
--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/betweenness/BetweennessCentrality.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/betweenness/BetweennessCentrality.java
@@ -132,7 +132,7 @@ public class BetweennessCentrality implements Computation<BetweennessMessage> {
 
         BetweennessValue value = vertex.value();
         IdSet arrivedVertices = value.arrivedVertices();
-        Id source = sequence.get(0);
+        Id source = sequence.getFirst();
         // The source vertex is arriving at first time
         if (!arrivedVertices.contains(source)) {
             arrivingVertices.add(source);

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/betweenness/BetweennessMessage.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/centrality/betweenness/BetweennessMessage.java
@@ -81,8 +81,8 @@ public class BetweennessMessage implements CustomizeValue<BetweennessMessage> {
         BetweennessMessage other = (BetweennessMessage) value;
         E.checkArgument(this.sequence.size() != 0, "Sequence can't be empty");
         E.checkArgument(other.sequence.size() != 0, "Sequence can't be empty");
-        Id selfSourceId = this.sequence.get(0);
-        Id otherSourceId = other.sequence.get(0);
+        Id selfSourceId = this.sequence.getFirst();
+        Id otherSourceId = other.sequence.getFirst();
         return selfSourceId.compareTo(otherSourceId);
     }
 }

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/cc/ClusteringCoefficient.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/cc/ClusteringCoefficient.java
@@ -64,7 +64,7 @@ public class ClusteringCoefficient extends TriangleCount {
         selfId.add(vertex.id());
 
         context.sendMessageToAllEdgesIf(vertex, selfId, (ids, targetId) -> {
-            return !ids.get(0).equals(targetId);
+            return !ids.getFirst().equals(targetId);
         });
         vertex.value(new ClusteringCoefficientValue());
     }

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/trianglecount/TriangleCount.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/community/trianglecount/TriangleCount.java
@@ -75,7 +75,7 @@ public class TriangleCount implements Computation<IdList> {
             while (messages.hasNext()) {
                 IdList idList = messages.next();
                 assert idList.size() == 1;
-                Id inId = idList.get(0);
+                Id inId = idList.getFirst();
                 if (!outNeighbors.contains(inId)) {
                     neighbors.add(inId);
                 }

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/RingsDetection.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/RingsDetection.java
@@ -70,7 +70,7 @@ public class RingsDetection implements Computation<IdList> {
         while (messages.hasNext()) {
             halt = false;
             IdList sequence = messages.next();
-            if (id.equals(sequence.get(0))) {
+            if (id.equals(sequence.getFirst())) {
                 // Use the smallest vertex record ring
                 boolean isMin = true;
                 for (int i = 1; i < sequence.size(); i++) {
@@ -96,7 +96,7 @@ public class RingsDetection implements Computation<IdList> {
                     }
                 }
                 // Field ringId is smallest vertex id in path
-                Id ringId = sequence.get(0);
+                Id ringId = sequence.getFirst();
                 if (!contains) {
                     sequence.add(vertex.id());
                     for (Edge edge : vertex.edges()) {

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/filter/RingsDetectionWithFilter.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/path/rings/filter/RingsDetectionWithFilter.java
@@ -77,7 +77,7 @@ public class RingsDetectionWithFilter
                 halt = false;
                 RingsDetectionMessage message = messages.next();
                 IdList path = message.path();
-                if (vertexId.equals(path.get(0))) {
+                if (vertexId.equals(path.getFirst())) {
                     // Use the smallest vertex record ring
                     boolean isMin = true;
                     for (int i = 0; i < path.size(); i++) {

--- a/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/sampling/RandomWalk.java
+++ b/computer-algorithm/src/main/java/org/apache/hugegraph/computer/algorithm/sampling/RandomWalk.java
@@ -177,7 +177,7 @@ public class RandomWalk implements Computation<RandomWalkMessage> {
      */
     private Id getSourceId(IdList path) {
         // the first id of path is the source id
-        return path.get(0);
+        return path.getFirst();
     }
 
     /**

--- a/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/ListValue.java
+++ b/computer-api/src/main/java/org/apache/hugegraph/computer/core/graph/value/ListValue.java
@@ -90,6 +90,13 @@ public class ListValue<T extends Tvalue<?>> implements Tvalue<List<Object>> {
         return this.values.get(index);
     }
 
+    public T getFirst() {
+        if (this.values.size() == 0) {
+            throw new NoSuchElementException("The list is empty");
+        }
+        return this.values.get(0);
+    }
+
     public T getLast() {
         int index = this.values.size() - 1;
         if (index < 0) {

--- a/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/ListValueTest.java
+++ b/computer-test/src/main/java/org/apache/hugegraph/computer/core/graph/value/ListValueTest.java
@@ -135,6 +135,23 @@ public class ListValueTest extends UnitTestBase {
     }
 
     @Test
+    public void testGetFirst() {
+        ListValue<IntValue> value = new ListValue<>(ValueType.INT);
+
+        Assert.assertThrows(NoSuchElementException.class, () -> {
+            value.getFirst();
+        }, e -> {
+            Assert.assertContains("The list is empty", e.getMessage());
+        });
+
+        value.add(new IntValue(100));
+        Assert.assertEquals(100, value.getFirst().value());
+
+        value.add(new IntValue(200));
+        Assert.assertEquals(100, value.getFirst().value());
+    }
+
+    @Test
     public void testGetLast() {
         ListValue<IntValue> value1 = new ListValue<>(ValueType.INT);
 


### PR DESCRIPTION
## Purpose of the PR

- close #281

## Main Changes

`ListValue.getFirst()` replaces `ListValue.get(0)`.

## Verifying these changes

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [X] Need tests and can be verified as follows.
Unit test: `org.apache.hugegraph.computer.core.graph.value.ListValueTest#testGetFirst`


## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [X]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [X]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
