### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://github.com/apache/hugegraph-computer/actions/workflows/ci.yml/badge.svg)](https://github.com/apache/hugegraph-computer/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/apache/incubator-hugegraph-computer/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/incubator-hugegraph-computer)
 [![Docker Pulls](https://img.shields.io/docker/pulls/hugegraph/hugegraph-computer)](https://hub.docker.com/repository/docker/hugegraph/hugegraph-computer)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/apache/hugegraph-computer)
 
 The [hugegraph-computer](./computer/README.md) is a distributed graph processing system for hugegraph. 
 (Also, the in-memory computing engine(vermeer) is on the way 🚧)


### PR DESCRIPTION
## Description

This PR adds a DeepWiki badge to the README file, enabling users to easily access interactive, AI-powered documentation for the HugeGraph Computer project.

## Changes
- Added DeepWiki badge in the badges section of README.md
- Badge links to https://deepwiki.com/apache/hugegraph-computer for up-to-date, interactive documentation

## Benefits
- Provides users with an alternative way to explore documentation through AI assistance
- Enables DeepWiki to automatically index and update project documentation
- Improves documentation accessibility and user experience

## Badge Preview
[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/apache/hugegraph-computer)