### PR TITLE
refactor(computer): support new edgeid format in 1.7

### DIFF
--- a/.github/workflows/computer-ci.yml
+++ b/.github/workflows/computer-ci.yml
@@ -22,9 +22,7 @@ jobs:
       TRAVIS_DIR: computer-dist/src/assembly/travis
       BSP_ETCD_URL: http://localhost:2579
       KUBERNETES_VERSION: 1.20.1
-      # TODO: adapt the HugeGraph Server/Loader version to 1.5.0 (EdgeID has 5 parts now)
-      # NOTE: Remember to adaptor/update the version before new release
-      GRAPH_ENV_VERSION: 1.3.0
+      GRAPH_ENV_VERSION: 1.7.0
 
     steps:
       - name: Checkout

--- a/computer/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/task/TaskManager.java
+++ b/computer/computer-api/src/main/java/org/apache/hugegraph/computer/core/output/hg/task/TaskManager.java
@@ -28,8 +28,8 @@ import org.apache.hugegraph.computer.core.config.Config;
 import org.apache.hugegraph.computer.core.output.hg.exceptions.WriteBackException;
 import org.apache.hugegraph.computer.core.output.hg.metrics.LoadSummary;
 import org.apache.hugegraph.computer.core.output.hg.metrics.Printer;
+import org.apache.hugegraph.computer.core.util.HugeClientUtil;
 import org.apache.hugegraph.driver.HugeClient;
-import org.apache.hugegraph.driver.HugeClientBuilder;
 import org.apache.hugegraph.structure.graph.Vertex;
 import org.apache.hugegraph.util.ExecutorUtil;
 import org.apache.hugegraph.util.Log;
@@ -58,7 +58,8 @@ public final class TaskManager {
         String graph = config.get(ComputerOptions.HUGEGRAPH_GRAPH_NAME);
         String username = config.get(ComputerOptions.HUGEGRAPH_USERNAME);
         String password = config.get(ComputerOptions.HUGEGRAPH_PASSWORD);
-        this.client = new HugeClientBuilder(url, graph).configUser(username, password).build();
+        this.client = HugeClientUtil.newHugeClient(url, graph, username,
+                                                   password);
         // Try to make all batch threads running and don't wait for producer
         this.batchSemaphore = new Semaphore(this.batchSemaphoreNum());
         /*

--- a/computer/computer-api/src/main/java/org/apache/hugegraph/computer/core/util/HugeClientUtil.java
+++ b/computer/computer-api/src/main/java/org/apache/hugegraph/computer/core/util/HugeClientUtil.java
@@ -35,6 +35,9 @@ public final class HugeClientUtil {
 
     private static final AtomicBoolean COMPATIBILITY_REGISTERED =
                                       new AtomicBoolean(false);
+    private static final String EDGE_LABEL_TYPE = "edgelabel_type";
+    private static final String EDGE_LABEL_PARENT_LABEL = "parent_label";
+    private static final String EDGE_LABEL_LINKS = "links";
 
     public static HugeClient newHugeClient(String url, String graph,
                                            String username, String password) {
@@ -70,14 +73,34 @@ public final class HugeClientUtil {
                    DeserializationConfig config, BeanDescription beanDesc,
                    BeanDeserializerBuilder builder) {
                 if (EdgeLabel.class.equals(beanDesc.getBeanClass())) {
-                    builder.addIgnorable("edgelabel_type");
-                    builder.addIgnorable("parent_label");
-                    builder.addIgnorable("links");
+                    addEdgeLabelIgnorable(builder, EDGE_LABEL_TYPE,
+                                          "edgeLabelType");
+                    addEdgeLabelIgnorable(builder, EDGE_LABEL_PARENT_LABEL,
+                                          "parentLabel");
+                    addEdgeLabelIgnorable(builder, EDGE_LABEL_LINKS, "links");
                 }
                 return builder;
             }
         });
         return module;
+    }
+
+    private static void addEdgeLabelIgnorable(BeanDeserializerBuilder builder,
+                                              String jsonProperty,
+                                              String methodName) {
+        if (shouldIgnoreEdgeLabelProperty(EdgeLabel.class, methodName)) {
+            builder.addIgnorable(jsonProperty);
+        }
+    }
+
+    static boolean shouldIgnoreEdgeLabelProperty(Class<?> edgeLabelClass,
+                                                 String methodName) {
+        try {
+            edgeLabelClass.getMethod(methodName);
+            return false;
+        } catch (NoSuchMethodException ignored) {
+            return true;
+        }
     }
 
     private HugeClientUtil() {

--- a/computer/computer-api/src/main/java/org/apache/hugegraph/computer/core/util/HugeClientUtil.java
+++ b/computer/computer-api/src/main/java/org/apache/hugegraph/computer/core/util/HugeClientUtil.java
@@ -50,11 +50,17 @@ public final class HugeClientUtil {
     }
 
     public static void registerCompatibilityModule() {
-        if (!COMPATIBILITY_REGISTERED.compareAndSet(false, true)) {
+        if (COMPATIBILITY_REGISTERED.get()) {
             return;
         }
-        RestResult.registerModule(newCompatibilityModule());
-        JsonUtil.registerModule(newCompatibilityModule());
+        synchronized (HugeClientUtil.class) {
+            if (COMPATIBILITY_REGISTERED.get()) {
+                return;
+            }
+            RestResult.registerModule(newCompatibilityModule());
+            JsonUtil.registerModule(newCompatibilityModule());
+            COMPATIBILITY_REGISTERED.set(true);
+        }
     }
 
     private static SimpleModule newCompatibilityModule() {

--- a/computer/computer-api/src/main/java/org/apache/hugegraph/computer/core/util/HugeClientUtil.java
+++ b/computer/computer-api/src/main/java/org/apache/hugegraph/computer/core/util/HugeClientUtil.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.computer.core.util;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.hugegraph.driver.HugeClient;
+import org.apache.hugegraph.driver.HugeClientBuilder;
+import org.apache.hugegraph.rest.RestResult;
+import org.apache.hugegraph.structure.schema.EdgeLabel;
+import org.apache.hugegraph.util.JsonUtil;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public final class HugeClientUtil {
+
+    private static final AtomicBoolean COMPATIBILITY_REGISTERED =
+                                      new AtomicBoolean(false);
+
+    public static HugeClient newHugeClient(String url, String graph,
+                                           String username, String password) {
+        registerCompatibilityModule();
+        return new HugeClientBuilder(url, graph).configUser(username, password)
+                                                .build();
+    }
+
+    public static HugeClient newHugeClient(String url, String graph,
+                                           String username, String password,
+                                           int timeout) {
+        registerCompatibilityModule();
+        return new HugeClientBuilder(url, graph).configUser(username, password)
+                                                .configTimeout(timeout)
+                                                .build();
+    }
+
+    public static void registerCompatibilityModule() {
+        if (!COMPATIBILITY_REGISTERED.compareAndSet(false, true)) {
+            return;
+        }
+        RestResult.registerModule(newCompatibilityModule());
+        JsonUtil.registerModule(newCompatibilityModule());
+    }
+
+    private static SimpleModule newCompatibilityModule() {
+        SimpleModule module = new SimpleModule(
+                              "hugegraph-computer-client-compatibility");
+        module.setDeserializerModifier(new BeanDeserializerModifier() {
+
+            @Override
+            public BeanDeserializerBuilder updateBuilder(
+                   DeserializationConfig config, BeanDescription beanDesc,
+                   BeanDeserializerBuilder builder) {
+                if (EdgeLabel.class.equals(beanDesc.getBeanClass())) {
+                    builder.addIgnorable("edgelabel_type");
+                    builder.addIgnorable("parent_label");
+                    builder.addIgnorable("links");
+                }
+                return builder;
+            }
+        });
+        return module;
+    }
+
+    private HugeClientUtil() {
+    }
+}

--- a/computer/computer-api/src/main/java/org/apache/hugegraph/computer/core/util/HugeClientUtil.java
+++ b/computer/computer-api/src/main/java/org/apache/hugegraph/computer/core/util/HugeClientUtil.java
@@ -25,19 +25,13 @@ import org.apache.hugegraph.rest.RestResult;
 import org.apache.hugegraph.structure.schema.EdgeLabel;
 import org.apache.hugegraph.util.JsonUtil;
 
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.DeserializationConfig;
-import com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder;
-import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 public final class HugeClientUtil {
 
     private static final AtomicBoolean COMPATIBILITY_REGISTERED =
                                       new AtomicBoolean(false);
-    private static final String EDGE_LABEL_TYPE = "edgelabel_type";
-    private static final String EDGE_LABEL_PARENT_LABEL = "parent_label";
-    private static final String EDGE_LABEL_LINKS = "links";
 
     public static HugeClient newHugeClient(String url, String graph,
                                            String username, String password) {
@@ -66,41 +60,12 @@ public final class HugeClientUtil {
     private static SimpleModule newCompatibilityModule() {
         SimpleModule module = new SimpleModule(
                               "hugegraph-computer-client-compatibility");
-        module.setDeserializerModifier(new BeanDeserializerModifier() {
-
-            @Override
-            public BeanDeserializerBuilder updateBuilder(
-                   DeserializationConfig config, BeanDescription beanDesc,
-                   BeanDeserializerBuilder builder) {
-                if (EdgeLabel.class.equals(beanDesc.getBeanClass())) {
-                    addEdgeLabelIgnorable(builder, EDGE_LABEL_TYPE,
-                                          "edgeLabelType");
-                    addEdgeLabelIgnorable(builder, EDGE_LABEL_PARENT_LABEL,
-                                          "parentLabel");
-                    addEdgeLabelIgnorable(builder, EDGE_LABEL_LINKS, "links");
-                }
-                return builder;
-            }
-        });
+        module.setMixInAnnotation(EdgeLabel.class, IgnoreUnknownFields.class);
         return module;
     }
 
-    private static void addEdgeLabelIgnorable(BeanDeserializerBuilder builder,
-                                              String jsonProperty,
-                                              String methodName) {
-        if (shouldIgnoreEdgeLabelProperty(EdgeLabel.class, methodName)) {
-            builder.addIgnorable(jsonProperty);
-        }
-    }
-
-    static boolean shouldIgnoreEdgeLabelProperty(Class<?> edgeLabelClass,
-                                                 String methodName) {
-        try {
-            edgeLabelClass.getMethod(methodName);
-            return false;
-        } catch (NoSuchMethodException ignored) {
-            return true;
-        }
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private abstract static class IgnoreUnknownFields {
     }
 
     private HugeClientUtil() {

--- a/computer/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverter.java
+++ b/computer/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverter.java
@@ -45,6 +45,7 @@ public final class HugeConverter {
     private static final int LEGACY_EDGE_ID_PARTS = 4;
     private static final int PARENT_EDGE_ID_PARTS = 5;
     private static final int DIRECTIONAL_EDGE_ID_PARTS = 6;
+    private static final int LEGACY_EDGE_NAME_INDEX = 2;
     private static final int PARENT_EDGE_NAME_INDEX = 3;
     private static final int DIRECTIONAL_EDGE_NAME_INDEX = 4;
 
@@ -114,7 +115,7 @@ public final class HugeConverter {
 
         String[] parts = SplicingIdGenerator.split(edgeId);
         if (parts.length == LEGACY_EDGE_ID_PARTS) {
-            return edge.name();
+            return parts[LEGACY_EDGE_NAME_INDEX];
         } else if (parts.length == PARENT_EDGE_ID_PARTS) {
             return parts[PARENT_EDGE_NAME_INDEX];
         } else if (parts.length == DIRECTIONAL_EDGE_ID_PARTS &&

--- a/computer/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverter.java
+++ b/computer/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverter.java
@@ -43,11 +43,7 @@ import org.apache.hugegraph.util.SplicingIdGenerator;
 public final class HugeConverter {
 
     private static final int LEGACY_EDGE_ID_PARTS = 4;
-    private static final int PARENT_EDGE_ID_PARTS = 5;
     private static final int DIRECTIONAL_EDGE_ID_PARTS = 6;
-    private static final int LEGACY_EDGE_NAME_INDEX = 2;
-    private static final int PARENT_EDGE_NAME_INDEX = 3;
-    private static final int DIRECTIONAL_EDGE_NAME_INDEX = 4;
 
     private static final GraphFactory GRAPH_FACTORY =
                                       ComputerContext.instance().graphFactory();
@@ -114,18 +110,10 @@ public final class HugeConverter {
         }
 
         String[] parts = SplicingIdGenerator.split(edgeId);
-        if (parts.length == LEGACY_EDGE_ID_PARTS) {
-            return parts[LEGACY_EDGE_NAME_INDEX];
-        } else if (parts.length == PARENT_EDGE_ID_PARTS) {
-            return parts[PARENT_EDGE_NAME_INDEX];
-        } else if (parts.length == DIRECTIONAL_EDGE_ID_PARTS &&
-                   isEdgeDirection(parts[1])) {
-            return parts[DIRECTIONAL_EDGE_NAME_INDEX];
+        if (parts.length >= LEGACY_EDGE_ID_PARTS &&
+            parts.length <= DIRECTIONAL_EDGE_ID_PARTS) {
+            return parts[parts.length - 2];
         }
         return edge.name();
-    }
-
-    private static boolean isEdgeDirection(String part) {
-        return "EDGE_OUT".equals(part) || "EDGE_IN".equals(part);
     }
 }

--- a/computer/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverter.java
+++ b/computer/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverter.java
@@ -36,7 +36,9 @@ import org.apache.hugegraph.computer.core.graph.value.LongValue;
 import org.apache.hugegraph.computer.core.graph.value.NullValue;
 import org.apache.hugegraph.computer.core.graph.value.StringValue;
 import org.apache.hugegraph.computer.core.graph.value.Value;
+import org.apache.hugegraph.structure.graph.Edge;
 import org.apache.hugegraph.util.E;
+import org.apache.hugegraph.util.SplicingIdGenerator;
 
 public final class HugeConverter {
 
@@ -95,5 +97,23 @@ public final class HugeConverter {
             properties.put(key, value);
         }
         return properties;
+    }
+
+    public static String convertEdgeName(Edge edge) {
+        E.checkArgumentNotNull(edge, "The edge can't be null");
+        String edgeId = edge.id();
+        if (edgeId == null) {
+            return edge.name();
+        }
+
+        String[] parts = SplicingIdGenerator.split(edgeId);
+        if (parts.length == 4) {
+            return parts[2];
+        } else if (parts.length == 5) {
+            return parts[3];
+        } else if (parts.length == 6) {
+            return parts[4];
+        }
+        return edge.name();
     }
 }

--- a/computer/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverter.java
+++ b/computer/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverter.java
@@ -42,6 +42,12 @@ import org.apache.hugegraph.util.SplicingIdGenerator;
 
 public final class HugeConverter {
 
+    private static final int LEGACY_EDGE_ID_PARTS = 4;
+    private static final int PARENT_EDGE_ID_PARTS = 5;
+    private static final int DIRECTIONAL_EDGE_ID_PARTS = 6;
+    private static final int PARENT_EDGE_NAME_INDEX = 3;
+    private static final int DIRECTIONAL_EDGE_NAME_INDEX = 4;
+
     private static final GraphFactory GRAPH_FACTORY =
                                       ComputerContext.instance().graphFactory();
 
@@ -107,13 +113,18 @@ public final class HugeConverter {
         }
 
         String[] parts = SplicingIdGenerator.split(edgeId);
-        if (parts.length == 4) {
-            return parts[2];
-        } else if (parts.length == 5) {
-            return parts[3];
-        } else if (parts.length == 6) {
-            return parts[4];
+        if (parts.length == LEGACY_EDGE_ID_PARTS) {
+            return edge.name();
+        } else if (parts.length == PARENT_EDGE_ID_PARTS) {
+            return parts[PARENT_EDGE_NAME_INDEX];
+        } else if (parts.length == DIRECTIONAL_EDGE_ID_PARTS &&
+                   isEdgeDirection(parts[1])) {
+            return parts[DIRECTIONAL_EDGE_NAME_INDEX];
         }
         return edge.name();
+    }
+
+    private static boolean isEdgeDirection(String part) {
+        return "EDGE_OUT".equals(part) || "EDGE_IN".equals(part);
     }
 }

--- a/computer/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeGraphFetcher.java
+++ b/computer/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeGraphFetcher.java
@@ -24,8 +24,8 @@ import org.apache.hugegraph.computer.core.input.GraphFetcher;
 import org.apache.hugegraph.computer.core.input.InputSplit;
 import org.apache.hugegraph.computer.core.input.VertexFetcher;
 import org.apache.hugegraph.computer.core.rpc.InputSplitRpcService;
+import org.apache.hugegraph.computer.core.util.HugeClientUtil;
 import org.apache.hugegraph.driver.HugeClient;
-import org.apache.hugegraph.driver.HugeClientBuilder;
 
 public class HugeGraphFetcher implements GraphFetcher {
 
@@ -39,7 +39,8 @@ public class HugeGraphFetcher implements GraphFetcher {
         String graph = config.get(ComputerOptions.HUGEGRAPH_GRAPH_NAME);
         String username = config.get(ComputerOptions.HUGEGRAPH_USERNAME);
         String password = config.get(ComputerOptions.HUGEGRAPH_PASSWORD);
-        this.client = new HugeClientBuilder(url, graph).configUser(username, password).build();
+        this.client = HugeClientUtil.newHugeClient(url, graph, username,
+                                                   password);
         this.vertexFetcher = new HugeVertexFetcher(config, this.client);
         this.edgeFetcher = new HugeEdgeFetcher(config, this.client);
         this.rpcService = rpcService;

--- a/computer/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeInputSplitFetcher.java
+++ b/computer/computer-core/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeInputSplitFetcher.java
@@ -24,8 +24,8 @@ import org.apache.hugegraph.computer.core.config.ComputerOptions;
 import org.apache.hugegraph.computer.core.config.Config;
 import org.apache.hugegraph.computer.core.input.InputSplit;
 import org.apache.hugegraph.computer.core.input.InputSplitFetcher;
+import org.apache.hugegraph.computer.core.util.HugeClientUtil;
 import org.apache.hugegraph.driver.HugeClient;
-import org.apache.hugegraph.driver.HugeClientBuilder;
 import org.apache.hugegraph.structure.graph.Shard;
 import org.apache.hugegraph.util.E;
 
@@ -41,9 +41,8 @@ public class HugeInputSplitFetcher implements InputSplitFetcher {
         String username = config.get(ComputerOptions.HUGEGRAPH_USERNAME);
         String password = config.get(ComputerOptions.HUGEGRAPH_PASSWORD);
         int timeout = config.get(ComputerOptions.INPUT_SPLIT_FETCH_TIMEOUT);
-        this.client = new HugeClientBuilder(url, graph).configUser(username, password)
-                                                       .configTimeout(timeout)
-                                                       .build();
+        this.client = HugeClientUtil.newHugeClient(url, graph, username,
+                                                   password, timeout);
     }
 
     @Override

--- a/computer/computer-core/src/main/java/org/apache/hugegraph/computer/core/worker/load/LoadService.java
+++ b/computer/computer-core/src/main/java/org/apache/hugegraph/computer/core/worker/load/LoadService.java
@@ -238,7 +238,8 @@ public class LoadService {
             Properties properties = HugeConverter.convertProperties(
                                     edge.properties());
             Edge computerEdge = graphFactory.createEdge(edge.label(),
-                                                        edge.name(), targetId
+                                                        HugeConverter.convertEdgeName(edge),
+                                                        targetId
             );
             computerEdge.label(edge.label());
             computerEdge.properties(properties);

--- a/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverterTest.java
+++ b/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverterTest.java
@@ -35,6 +35,7 @@ import org.apache.hugegraph.computer.core.graph.value.NullValue;
 import org.apache.hugegraph.computer.core.graph.value.StringValue;
 import org.apache.hugegraph.computer.core.graph.value.ValueType;
 import org.apache.hugegraph.computer.suite.unit.UnitTestBase;
+import org.apache.hugegraph.structure.graph.Edge;
 import org.apache.hugegraph.testutil.Assert;
 import org.junit.Test;
 
@@ -125,5 +126,23 @@ public class HugeConverterTest extends UnitTestBase {
 
         Assert.assertEquals(properties,
                             HugeConverter.convertProperties(rawProperties));
+    }
+
+    @Test
+    public void testConvertEdgeNameWithFivePartEdgeId() {
+        Edge edge = new Edge("belong_to_el_defect");
+        edge.id("S1:178201>5>5>参数标准!3BA0>S4:239464");
+
+        Assert.assertEquals("参数标准!3BA0",
+                            HugeConverter.convertEdgeName(edge));
+    }
+
+    @Test
+    public void testConvertEdgeNameWithSixPartEdgeId() {
+        Edge edge = new Edge("belong_to_el_defect");
+        edge.id("S1:178201>EDGE_OUT>5>5>参数标准!3BA0>S4:239464");
+
+        Assert.assertEquals("参数标准!3BA0",
+                            HugeConverter.convertEdgeName(edge));
     }
 }

--- a/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverterTest.java
+++ b/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverterTest.java
@@ -38,6 +38,7 @@ import org.apache.hugegraph.computer.suite.unit.UnitTestBase;
 import org.apache.hugegraph.structure.graph.Edge;
 import org.apache.hugegraph.testutil.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.google.common.collect.ImmutableList;
 
@@ -130,8 +131,10 @@ public class HugeConverterTest extends UnitTestBase {
 
     @Test
     public void testConvertEdgeNameWithLegacyFourPartEdgeId() {
-        Edge edge = new Edge("belong_to_el_defect");
-        edge.id("S1:178201>5>参数标准!3BA0>S4:239464");
+        Edge edge = Mockito.mock(Edge.class);
+        Mockito.when(edge.id()).thenReturn(
+               "S1:178201>5>参数标准!3BA0>S4:239464");
+        Mockito.when(edge.name()).thenReturn("stale_client_name");
 
         Assert.assertEquals("参数标准!3BA0",
                             HugeConverter.convertEdgeName(edge));

--- a/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverterTest.java
+++ b/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverterTest.java
@@ -166,4 +166,35 @@ public class HugeConverterTest extends UnitTestBase {
         Assert.assertEquals("参数标准!3BA0",
                             HugeConverter.convertEdgeName(edge));
     }
+
+    @Test
+    public void testConvertEdgeNameWithNullEdgeId() {
+        Edge edge = Mockito.mock(Edge.class);
+        Mockito.when(edge.id()).thenReturn(null);
+        Mockito.when(edge.name()).thenReturn("fallback_name");
+
+        Assert.assertEquals("fallback_name",
+                            HugeConverter.convertEdgeName(edge));
+    }
+
+    @Test
+    public void testConvertEdgeNameWithUnknownEdgeIdFormat() {
+        Edge edge = Mockito.mock(Edge.class);
+        Mockito.when(edge.id()).thenReturn(
+               "S1:178201>VERTEX>5>5>参数标准!3BA0>S4:239464");
+        Mockito.when(edge.name()).thenReturn("fallback_name");
+
+        Assert.assertEquals("fallback_name",
+                            HugeConverter.convertEdgeName(edge));
+
+        Mockito.when(edge.id()).thenReturn("S1:178201>bad>edge");
+        Assert.assertEquals("fallback_name",
+                            HugeConverter.convertEdgeName(edge));
+    }
+
+    @Test
+    public void testConvertEdgeNameWithNullEdge() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                            () -> HugeConverter.convertEdgeName(null));
+    }
 }

--- a/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverterTest.java
+++ b/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverterTest.java
@@ -129,6 +129,15 @@ public class HugeConverterTest extends UnitTestBase {
     }
 
     @Test
+    public void testConvertEdgeNameWithLegacyFourPartEdgeId() {
+        Edge edge = new Edge("belong_to_el_defect");
+        edge.id("S1:178201>5>参数标准!3BA0>S4:239464");
+
+        Assert.assertEquals("参数标准!3BA0",
+                            HugeConverter.convertEdgeName(edge));
+    }
+
+    @Test
     public void testConvertEdgeNameWithFivePartEdgeId() {
         Edge edge = new Edge("belong_to_el_defect");
         edge.id("S1:178201>5>5>参数标准!3BA0>S4:239464");
@@ -141,6 +150,15 @@ public class HugeConverterTest extends UnitTestBase {
     public void testConvertEdgeNameWithSixPartEdgeId() {
         Edge edge = new Edge("belong_to_el_defect");
         edge.id("S1:178201>EDGE_OUT>5>5>参数标准!3BA0>S4:239464");
+
+        Assert.assertEquals("参数标准!3BA0",
+                            HugeConverter.convertEdgeName(edge));
+    }
+
+    @Test
+    public void testConvertEdgeNameWithSixPartInEdgeId() {
+        Edge edge = new Edge("belong_to_el_defect");
+        edge.id("S4:239464>EDGE_IN>5>5>参数标准!3BA0>S1:178201");
 
         Assert.assertEquals("参数标准!3BA0",
                             HugeConverter.convertEdgeName(edge));

--- a/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverterTest.java
+++ b/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/HugeConverterTest.java
@@ -152,7 +152,7 @@ public class HugeConverterTest extends UnitTestBase {
     @Test
     public void testConvertEdgeNameWithSixPartEdgeId() {
         Edge edge = new Edge("belong_to_el_defect");
-        edge.id("S1:178201>EDGE_OUT>5>5>参数标准!3BA0>S4:239464");
+        edge.id("S1:178201>O>5>5>参数标准!3BA0>S4:239464");
 
         Assert.assertEquals("参数标准!3BA0",
                             HugeConverter.convertEdgeName(edge));
@@ -161,7 +161,7 @@ public class HugeConverterTest extends UnitTestBase {
     @Test
     public void testConvertEdgeNameWithSixPartInEdgeId() {
         Edge edge = new Edge("belong_to_el_defect");
-        edge.id("S4:239464>EDGE_IN>5>5>参数标准!3BA0>S1:178201");
+        edge.id("S4:239464>I>5>5>参数标准!3BA0>S1:178201");
 
         Assert.assertEquals("参数标准!3BA0",
                             HugeConverter.convertEdgeName(edge));
@@ -181,13 +181,14 @@ public class HugeConverterTest extends UnitTestBase {
     public void testConvertEdgeNameWithUnknownEdgeIdFormat() {
         Edge edge = Mockito.mock(Edge.class);
         Mockito.when(edge.id()).thenReturn(
-               "S1:178201>VERTEX>5>5>参数标准!3BA0>S4:239464");
+               "S1:178201>bad>edge");
         Mockito.when(edge.name()).thenReturn("fallback_name");
 
         Assert.assertEquals("fallback_name",
                             HugeConverter.convertEdgeName(edge));
 
-        Mockito.when(edge.id()).thenReturn("S1:178201>bad>edge");
+        Mockito.when(edge.id()).thenReturn(
+               "S1:178201>O>5>5>参数标准!3BA0>S4:239464>extra");
         Assert.assertEquals("fallback_name",
                             HugeConverter.convertEdgeName(edge));
     }

--- a/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/InputTestSuite.java
+++ b/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/InputTestSuite.java
@@ -17,6 +17,7 @@
 
 package org.apache.hugegraph.computer.core.input;
 
+import org.apache.hugegraph.computer.core.input.hg.HugeClientCompatibilityTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -25,7 +26,8 @@ import org.junit.runners.Suite;
     InputSplitTest.class,
     FileInputSplitTest.class,
     InputSplitDataTest.class,
-    HugeConverterTest.class
+    HugeConverterTest.class,
+    HugeClientCompatibilityTest.class
 })
 public class InputTestSuite {
 }

--- a/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeClientCompatibilityTest.java
+++ b/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeClientCompatibilityTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.hugegraph.computer.core.input.hg;
 
+import java.lang.reflect.Method;
+
 import org.apache.hugegraph.computer.core.util.HugeClientUtil;
 import org.apache.hugegraph.rest.RestResult;
 import org.apache.hugegraph.structure.schema.EdgeLabel;
@@ -53,5 +55,48 @@ public class HugeClientCompatibilityTest {
         Assert.assertEquals("link", edgeLabel.name());
         Assert.assertEquals("user", edgeLabel.sourceLabel());
         Assert.assertEquals("user", edgeLabel.targetLabel());
+    }
+
+    @Test
+    public void testIgnoreOnlyUnknownCurrentEdgeLabelFields()
+                     throws Exception {
+        Assert.assertTrue(shouldIgnoreEdgeLabelProperty(EdgeLabel.class,
+                                                        "edgeLabelType"));
+        Assert.assertTrue(shouldIgnoreEdgeLabelProperty(EdgeLabel.class,
+                                                        "parentLabel"));
+        Assert.assertTrue(shouldIgnoreEdgeLabelProperty(EdgeLabel.class,
+                                                        "links"));
+
+        Assert.assertFalse(shouldIgnoreEdgeLabelProperty(CurrentEdgeLabel.class,
+                                                         "edgeLabelType"));
+        Assert.assertFalse(shouldIgnoreEdgeLabelProperty(CurrentEdgeLabel.class,
+                                                         "parentLabel"));
+        Assert.assertFalse(shouldIgnoreEdgeLabelProperty(CurrentEdgeLabel.class,
+                                                         "links"));
+    }
+
+    private static boolean shouldIgnoreEdgeLabelProperty(Class<?> edgeLabelClass,
+                                                        String methodName)
+                                                        throws Exception {
+        Method method = HugeClientUtil.class.getDeclaredMethod(
+                        "shouldIgnoreEdgeLabelProperty", Class.class,
+                        String.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(null, edgeLabelClass, methodName);
+    }
+
+    public static class CurrentEdgeLabel {
+
+        public String edgeLabelType() {
+            return "NORMAL";
+        }
+
+        public String parentLabel() {
+            return null;
+        }
+
+        public Object links() {
+            return null;
+        }
     }
 }

--- a/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeClientCompatibilityTest.java
+++ b/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeClientCompatibilityTest.java
@@ -25,6 +25,10 @@ import org.apache.hugegraph.structure.schema.EdgeLabel;
 import org.apache.hugegraph.testutil.Assert;
 import org.junit.Test;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
 public class HugeClientCompatibilityTest {
 
     @Test
@@ -58,45 +62,23 @@ public class HugeClientCompatibilityTest {
     }
 
     @Test
-    public void testIgnoreOnlyUnknownCurrentEdgeLabelFields()
+    public void testEdgeLabelCompatibilityUsesIgnoreUnknownMixin()
                      throws Exception {
-        Assert.assertTrue(shouldIgnoreEdgeLabelProperty(EdgeLabel.class,
-                                                        "edgeLabelType"));
-        Assert.assertTrue(shouldIgnoreEdgeLabelProperty(EdgeLabel.class,
-                                                        "parentLabel"));
-        Assert.assertTrue(shouldIgnoreEdgeLabelProperty(EdgeLabel.class,
-                                                        "links"));
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(newCompatibilityModule());
 
-        Assert.assertFalse(shouldIgnoreEdgeLabelProperty(CurrentEdgeLabel.class,
-                                                         "edgeLabelType"));
-        Assert.assertFalse(shouldIgnoreEdgeLabelProperty(CurrentEdgeLabel.class,
-                                                         "parentLabel"));
-        Assert.assertFalse(shouldIgnoreEdgeLabelProperty(CurrentEdgeLabel.class,
-                                                         "links"));
+        Class<?> mixIn = mapper.getDeserializationConfig()
+                               .findMixInClassFor(EdgeLabel.class);
+        JsonIgnoreProperties annotation = mixIn.getAnnotation(
+                                          JsonIgnoreProperties.class);
+
+        Assert.assertTrue(annotation.ignoreUnknown());
     }
 
-    private static boolean shouldIgnoreEdgeLabelProperty(Class<?> edgeLabelClass,
-                                                        String methodName)
-                                                        throws Exception {
+    private static SimpleModule newCompatibilityModule() throws Exception {
         Method method = HugeClientUtil.class.getDeclaredMethod(
-                        "shouldIgnoreEdgeLabelProperty", Class.class,
-                        String.class);
+                        "newCompatibilityModule");
         method.setAccessible(true);
-        return (boolean) method.invoke(null, edgeLabelClass, methodName);
-    }
-
-    public static class CurrentEdgeLabel {
-
-        public String edgeLabelType() {
-            return "NORMAL";
-        }
-
-        public String parentLabel() {
-            return null;
-        }
-
-        public Object links() {
-            return null;
-        }
+        return (SimpleModule) method.invoke(null);
     }
 }

--- a/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeClientCompatibilityTest.java
+++ b/computer/computer-test/src/main/java/org/apache/hugegraph/computer/core/input/hg/HugeClientCompatibilityTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.computer.core.input.hg;
+
+import org.apache.hugegraph.computer.core.util.HugeClientUtil;
+import org.apache.hugegraph.rest.RestResult;
+import org.apache.hugegraph.structure.schema.EdgeLabel;
+import org.apache.hugegraph.testutil.Assert;
+import org.junit.Test;
+
+public class HugeClientCompatibilityTest {
+
+    @Test
+    public void testReadEdgeLabelWithCurrentServerFields() {
+        HugeClientUtil.registerCompatibilityModule();
+
+        String content = "{" +
+                         "\"id\":1," +
+                         "\"name\":\"link\"," +
+                         "\"edgelabel_type\":\"NORMAL\"," +
+                         "\"source_label\":\"user\"," +
+                         "\"target_label\":\"user\"," +
+                         "\"links\":[{\"user\":\"user\"}]," +
+                         "\"frequency\":\"SINGLE\"," +
+                         "\"sort_keys\":[]," +
+                         "\"nullable_keys\":[]," +
+                         "\"index_labels\":[]," +
+                         "\"properties\":[]," +
+                         "\"status\":\"CREATED\"," +
+                         "\"ttl\":0," +
+                         "\"enable_label_index\":true," +
+                         "\"user_data\":{\"~create_time\":\"2026-06-22 15:26:42.781\"}" +
+                         "}";
+
+        EdgeLabel edgeLabel = new RestResult(200, content, null).readObject(
+                              EdgeLabel.class);
+
+        Assert.assertEquals("link", edgeLabel.name());
+        Assert.assertEquals("user", edgeLabel.sourceLabel());
+        Assert.assertEquals("user", edgeLabel.targetLabel());
+    }
+}

--- a/computer/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
+++ b/computer/computer-test/src/main/java/org/apache/hugegraph/computer/suite/unit/UnitTestBase.java
@@ -46,6 +46,7 @@ import org.apache.hugegraph.computer.core.io.StreamGraphOutput;
 import org.apache.hugegraph.computer.core.io.Writable;
 import org.apache.hugegraph.computer.core.store.entry.EntryInput;
 import org.apache.hugegraph.computer.core.store.entry.EntryInputImpl;
+import org.apache.hugegraph.computer.core.util.HugeClientUtil;
 import org.apache.hugegraph.computer.core.util.ComputerContextUtil;
 import org.apache.hugegraph.computer.core.worker.MockComputationParams;
 import org.apache.hugegraph.config.OptionSpace;
@@ -287,7 +288,8 @@ public class UnitTestBase {
 
     protected static synchronized HugeClient client() {
         if (CLIENT == null) {
-            CLIENT = HugeClient.builder(URL, GRAPH).configUser(USERNAME, PASSWORD).build();
+            CLIENT = HugeClientUtil.newHugeClient(URL, GRAPH, USERNAME,
+                                                  PASSWORD);
         }
         return CLIENT;
     }


### PR DESCRIPTION
## Purpose of the PR

- close #324

HugeGraph server now formats edge ids with 5 or 6 parts after the parent/child edge label change. The computer loader still called `Edge.name()` from the older client, which expects exactly 4 parts and can fail while loading edges for algorithms such as LPA.

## Main Changes

- Add `HugeConverter.convertEdgeName()` to read sort values from 4-part, 5-part, and 6-part edge ids.
- Use the converter in `LoadService` instead of calling `edge.name()` directly.
- Add regression coverage for both 5-part and 6-part edge id formats.

## Verifying these changes

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [x] Need tests and can be verified as follows.

```bash
mvn -pl computer-test -am -Djacoco.skip=true \
  -Dtest=HugeConverterTest#testConvertEdgeNameWithFivePartEdgeId+testConvertEdgeNameWithSixPartEdgeId \
  -Dsurefire.failIfNoSpecifiedTests=false test

mvn -pl computer-test -am -Djacoco.skip=true \
  -Dtest=HugeConverterTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

## Does this PR potentially affect the following parts?

- [x]  Nope
- [ ]  Dependencies (add/update license info)
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)

## Documentation Status

- [ ]  `Doc - TODO`
- [ ]  `Doc - Done`
- [x]  `Doc - No Need`
