### PR TITLE
fix: replace revision with ${project.version} in artifacts path

### DIFF
--- a/computer/computer-dist/pom.xml
+++ b/computer/computer-dist/pom.xml
@@ -109,10 +109,10 @@
                         </goals>
                         <configuration>
                             <target>
-                                <copy file="${top.level.dir}/computer-algorithm/target/computer-algorithm-${revision}.jar"
+                                <copy file="${top.level.dir}/computer-algorithm/target/computer-algorithm-${project.version}.jar"
                                       tofile="${top.level.dir}/${final.name}/algorithm/builtin-algorithm.jar"
                                       overwrite="true"/>
-                                <copy file="${top.level.dir}/computer-k8s-operator/target/hugegraph-computer-operator-${revision}.jar"
+                                <copy file="${top.level.dir}/computer-k8s-operator/target/hugegraph-computer-operator-${project.version}.jar"
                                       tofile="${top.level.dir}/${final.name}/k8s-operator/hugegraph-computer-operator.jar"
                                       overwrite="true"/>
                                 <tar destfile="${top.level.dir}/target/${final.name}.tar.gz"

--- a/computer/computer-k8s-operator/pom.xml
+++ b/computer/computer-k8s-operator/pom.xml
@@ -36,7 +36,7 @@
     </dependencies>
 
     <build>
-        <finalName>hugegraph-computer-operator-${revision}</finalName>
+        <finalName>hugegraph-computer-operator-${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR will fix/close a issue, type the message "close xxx" (xxx is the link of related issue) in the content, github will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after published)
-->

## Purpose of the PR

- close #351  <!-- or use "fix #xxx", "xxx" is the ID-link of related issue, e.g: close #257 -->

The root POM uses `${revision}` as the version property. However, two files reference `${revision}` directly in file path strings and `<finalName>` When `mvn versions:set -DnewVersion=X.Y.Z` is run, it updates `<version>` tags and occurences of `${version}` with newVersion but not in the strings and `<finalName>`— causing the copy tasks to look for JARs with the old version in their filename, breaking the build.

## Main Changes

1. **computer/computer-dist/pom.xml**:
   - Line 67, 75: Replace `${revision}` with `${project.version}` in `<copy>` task file path attributes
   - These paths reference JAR files copied during the distribution packaging phase
   - Using `${project.version}` ensures paths always match the actual artifact version

2. **computer/computer-k8s-operator/pom.xml**:
   - Line 39: Replace `${revision}` with `${project.version}` in `<finalName>` declaration
   - This ensures the output JAR filename matches the actual project version

### Why This Fix Works

- `${project.version}` is dynamically resolved from the `<version>` tag
- When `mvn versions:set` updates the `<version>` tag, `${project.version}` automatically reflects the new version
- File paths and artifact names will always be consistent with the actual built version

## Verifying these changes

<!-- Please pick the proper options below -->

- [x] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [ ] Need tests and can be verified as follows.

## Manual testing
- Build with `mvn clean package -DskipTests` succeeds
- Artifact filenames match the actual project version
- Can be tested with version update: `mvn versions:set -DnewVersion=1.8.0-test && mvn clean package -DskipTests`
  
    <!-- Please provide more details about verification

      For example:
      - If you test manually, please provide related screenshot.
     -->


## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [x]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [x]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
