### PR TITLE
refactor(vermeer): cross-compile Docker binaries

### DIFF
--- a/vermeer/Dockerfile
+++ b/vermeer/Dockerfile
@@ -14,14 +14,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM golang:1.23-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS builder
+ARG TARGETOS
+ARG TARGETARCH
 RUN apk add --no-cache npm bash curl
-COPY ./ /src/
 WORKDIR /src/
 ENV CGO_ENABLED="0"
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+COPY scripts/download_ui_assets.sh ./scripts/
+COPY ui/package.json ./ui/
 RUN ./scripts/download_ui_assets.sh
-RUN cd asset && go generate
-RUN go build -o /go/bin/app
+
+COPY ./ ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    cd asset && go generate
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /go/bin/app
 
 FROM alpine
 EXPOSE 8080

--- a/vermeer/Dockerfile
+++ b/vermeer/Dockerfile
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS builder
-ARG TARGETOS
-ARG TARGETARCH
 RUN apk add --no-cache npm bash curl
 WORKDIR /src/
 ENV CGO_ENABLED="0"
@@ -32,6 +30,8 @@ COPY ./ ./
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     cd asset && go generate
+ARG TARGETOS
+ARG TARGETARCH
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /go/bin/app


### PR DESCRIPTION
## Summary

- run the Vermeer Go builder on the native BuildKit platform
- cross-compile the final CGO-disabled binary with TARGETOS and TARGETARCH
- cache Go modules and compiler artifacts
- separate Go and UI dependency downloads from source copies

## Measured validation

- previous multi-platform build: 13 minutes 20 seconds
- optimized read-only build: 1 minute 54 seconds
- validation run: https://github.com/hugegraph/actions/actions/runs/29188192310

Companion cache and branch-validation workflow: hugegraph/actions#22.

## Verification

- the real amd64/arm64 BuildKit validation completed successfully
- confirmed CGO_ENABLED=0 and explicit TARGETOS/TARGETARCH cross-compilation
- verified Docker COPY paths against the vermeer context and .dockerignore
- git diff --check passed
- independent cross-repository review passed