### PR TITLE
fix(ci): use GET for rerun freshness check

### DIFF
--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -94,7 +94,9 @@ jobs:
             action="skip"
             reason="missing head repository metadata"
           else
-            latest_head_sha="$(gh api --method GET "repos/$HEAD_REPOSITORY/commits" -f sha="$HEAD_BRANCH" -F per_page=1 --jq '.[0].sha')"
+            if ! latest_head_sha="$(gh api --method GET "repos/$HEAD_REPOSITORY/commits" -f sha="$HEAD_BRANCH" -F per_page=1 --jq '.[0].sha')"; then
+              latest_head_sha=""
+            fi
 
             if [[ -z "$latest_head_sha" || "$latest_head_sha" == "null" ]]; then
               action="skip"

--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -94,7 +94,7 @@ jobs:
             action="skip"
             reason="missing head repository metadata"
           else
-            latest_head_sha="$(gh api "repos/$HEAD_REPOSITORY/commits" -f sha="$HEAD_BRANCH" -F per_page=1 --jq '.[0].sha' 2>/dev/null || true)"
+            latest_head_sha="$(gh api --method GET "repos/$HEAD_REPOSITORY/commits" -f sha="$HEAD_BRANCH" -F per_page=1 --jq '.[0].sha')"
 
             if [[ -z "$latest_head_sha" || "$latest_head_sha" == "null" ]]; then
               action="skip"


### PR DESCRIPTION
<!-- 
  Thank you very much for contributing to Apache HugeGraph, we are happy that you want to help us improve it!

  Here are some tips for you:
    1. If this is your first time, please read the [contributing guidelines](https://github.com/apache/hugegraph/blob/master/CONTRIBUTING.md)

    2. If a PR will fix/close a issue, type the message "close xxx" (xxx is the link of related issue) in the content, github will auto link it (Required)

    3. Name the PR title in "Google Commit Format", start with "feat | fix | perf | refactor | doc | chore", 
      such like: "feat(core): support the PageRank algorithm" or "fix: wrong break in the compute loop" (module is optional)
      skip it if you are unsure about which is the best component.

    4. One PR address one issue, better not to mix up multiple issues.

    5. Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]` (or click it directly after published)
-->

## Purpose of the PR

- close #xxx  <!-- or use "fix #xxx", "xxx" is the ID-link of related issue, e.g: close #257 -->

<!--
Please explain more context in this section, clarify why the changes are needed. 
For example:
- If you propose a new API, clarify the use case for a new API.
- If you fix a bug, you can clarify why it is a bug, and should associated with an issue.
-->

## Main Changes
Root Cause

The `gh api` command included `-f` and `-F` parameters without specifying an HTTP method. GitHub CLI therefore switched the request from GET to POST, causing the commits endpoint to return `404 Not Found`.

The error response was assigned to `latest_head_sha` and subsequently written to `$GITHUB_OUTPUT`, producing the following error:

```text
Unable to process file command 'output' successfully.
Invalid format '  "message": "Not Found",\r'
```

As a result, the workflow failed at the `Check source branch freshness` step before `gh run rerun` could be executed.

Previous Failures

The same error can be found in the following Rerun CI runs:

- [Rerun CI #3](https://github.com/apache/hugegraph-computer/actions/runs/27963996524)
- [Rerun CI #5](https://github.com/apache/hugegraph-computer/actions/runs/28030881553)
- [Rerun CI #7](https://github.com/apache/hugegraph-computer/actions/runs/28151389466)
- [Rerun CI #12](https://github.com/apache/hugegraph-computer/actions/runs/29161896190)
- [Rerun CI #15](https://github.com/apache/hugegraph-computer/actions/runs/29195282358)

Add --method GET to the source branch freshness API request.
Ensure the sha and per_page parameters are sent as GET query parameters.


<!-- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. These change logs are helpful for better ant faster reviews.)

For example:

- If you introduce a new feature, please show detailed design here or add the link of design documentation.
- If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
- If there is a discussion in the mailing list, please add the link. -->

## Verifying these changes

<!-- Please pick the proper options below -->

- [ ] Trivial rework / code cleanup without any test coverage. (No Need)
- [ ] Already covered by existing tests, such as *(please modify tests here)*.
- [ ] Need tests and can be verified as follows.
    <!-- Please provide more details about verification

      For example:
      - If you test manually, please provide related screenshot.
     -->


## Does this PR potentially affect the following parts?

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  Nope
- [ ]  Dependencies (add/update license info) <!-- Don't forget to add/update the info in "LICENSE" & "NOTICE" files (both in root & dist module) -->
- [ ]  Modify configurations
- [ ]  The public API
- [ ]  Other affects (typed here)

## Documentation Status

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ]  `Doc - TODO` <!-- Your PR changes impact docs and you will update later -->
- [ ]  `Doc - Done` <!-- Related docs have been already added or updated -->
- [ ]  `Doc - No Need` <!-- Your PR changes don't impact/need docs -->
